### PR TITLE
Ignore npm artifacts created by wrangler-action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # wrangler-action (GitHub Actions) installs wrangler via npm into the repo root,
 # creating these files as a side effect. They are not part of this project.
 node_modules/
-package.json
-package-lock.json
+/package.json
+/package-lock.json
 .dev.vars
 .wrangler/
 


### PR DESCRIPTION
## Summary
- `wrangler-action` installs wrangler via `npm` into the repo root during CI, creating `package.json` and `package-lock.json` as side effects
- These files caused a wrangler warning about uncommitted changes on every deploy
- Added them to `.gitignore` alongside `node_modules/` with an explanatory comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore settings to treat package management artifacts and related side-effect files as excluded; added a note clarifying a CLI tool is provided via project-level installation rather than tracked in the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->