### PR TITLE
Two-tier API proxy to reduce Worker invocations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy to Cloudflare
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-pages:
     concurrency:
       group: pages-prod-main
       cancel-in-progress: true
@@ -25,3 +25,21 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy web/ --project-name=oref-map
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-worker:
+    concurrency:
+      group: worker-prod-main
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 ## Project
 
-`oref-map` is a live alert map of Israel ("מפת העורף") showing colored Voronoi area polygons for alert statuses per location. It uses Leaflet + OpenStreetMap + d3-delaunay + polygon-clipping. Static assets on Cloudflare Pages; API proxy is a Cloudflare Worker with placement pinned to Israel.
+`oref-map` is a live alert map of Israel ("מפת העורף") showing colored Voronoi area polygons for alert statuses per location. It uses Leaflet + OpenStreetMap + d3-delaunay + polygon-clipping. Static assets on Cloudflare Pages; API proxy uses a two-tier architecture: Pages Functions serve TLV users directly, non-TLV users are redirected to a placement-pinned Worker.
 
 **Public URL**: https://oref-map.org
 
@@ -20,8 +20,9 @@ cd worker && npx wrangler deploy   # deploy API proxy Worker
 
 - `web/index.html` — Single-file map page (all JS/CSS inline)
 - `web/cities_geo.json` — Location → [lat, lng] lookup
-- `worker/src/index.js` — Cloudflare Worker: proxies all Oref APIs (placement: `azure:israelcentral`)
-- `worker/wrangler.toml` — Worker configuration with placement and route
+- `functions/api/` — Pages Functions: proxy for TLV users, 303 redirect for non-TLV
+- `worker/src/index.js` — Cloudflare Worker: fallback proxy for non-TLV users (placement: `azure:israelcentral`)
+- `worker/wrangler.toml` — Worker configuration with placement and `/api2/*` route
 - `docs/map-requirements.md` — Feature requirements doc
 
 ## Oref API details
@@ -81,7 +82,7 @@ Do **not** use `cat`/`category` for classification — the same number is reused
 The live API is polled every 1s for immediate danger display. The history API is polled every 10s because all-clear events are short-lived in the live API and would be missed — the history API is the reliable source for state transitions to green.
 
 ### Geo-blocking
-The Oref APIs geo-block non-Israeli IPs. Our proxy works because Israeli users route through Cloudflare's TLV edge. Users routed through non-Israeli edges will get 403 errors. See `docs/architecture.md` for details.
+The Oref APIs geo-block non-Israeli IPs. Pages Functions at `/api/*` check the colo — TLV users are proxied directly, non-TLV users get a 303 redirect to `/api2/*` which is handled by the placement-pinned Worker. See `docs/architecture.md` for details.
 
 # currentDate
 Today's date is 2026-03-04.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,13 +2,14 @@
 
 ## Overview
 
-A static single-page web app showing live Pikud HaOref (Home Front Command) alerts as colored area polygons on a map of Israel. No build step — all JS/CSS is inline in `web/index.html`. Static assets deployed on Cloudflare Pages; API proxy runs as a separate Cloudflare Worker with placement pinned to Israel.
+A static single-page web app showing live Pikud HaOref (Home Front Command) alerts as colored area polygons on a map of Israel. No build step — all JS/CSS is inline in `web/index.html`. Static assets deployed on Cloudflare Pages; API proxy uses a two-tier architecture: Pages Functions handle TLV-routed users directly, non-TLV users are redirected to a placement-pinned Worker.
 
 ## Stack
 
 - **Map**: Leaflet.js (v1.9.4) + OpenStreetMap tiles
 - **Voronoi**: d3-delaunay (v6) for polygon computation, polygon-clipping (v0.15) for clipping to Israel border
-- **API proxy**: Cloudflare Worker (`worker/`) with placement `region = "azure:israelcentral"`
+- **API proxy (tier 1)**: Cloudflare Pages Functions (`functions/api/`) — serves TLV users directly, redirects others
+- **API proxy (tier 2)**: Cloudflare Worker (`worker/`) with placement `region = "azure:israelcentral"` — fallback for non-TLV users
 - **No frameworks**: Vanilla JS, CSS
 
 ## Data Sources
@@ -41,7 +42,7 @@ The live API is a snapshot — all-clear alerts may only last a few seconds and 
 
 ### CORS
 
-The Oref APIs don't include `Access-Control-Allow-Origin`. The Worker proxy runs on the same domain (`oref-map.org/api/*` via Workers route), so no CORS headers are needed.
+The Oref APIs don't include `Access-Control-Allow-Origin`. Both the Pages Functions (`/api/*`) and the Worker (`/api2/*`) run on the same domain (`oref-map.org`), so no CORS headers are needed.
 
 ### Geo-blocking / Israeli IP requirement
 
@@ -49,7 +50,12 @@ The Oref APIs geo-block non-Israeli IPs. This was confirmed while building the `
 
 Previously, Pages Functions ran at the user's nearest Cloudflare edge. Users routed through non-Israeli edges (e.g., `FRA`, `ZRH`) got 403 errors because the proxy egressed from a non-Israeli IP.
 
-**Solution**: The API proxy now runs as a standalone Worker with explicit placement (`region = "azure:israelcentral"`). This forces the Worker to execute at Cloudflare's TLV data center regardless of where the user's request arrives. The `cf-placement` response header confirms the execution location (e.g., `remote-TLV`).
+**Solution**: A two-tier proxy architecture:
+
+1. **Pages Functions (`/api/*`)**: Check `request.cf.colo`. If TLV, proxy directly to Oref (free, no Worker invocation). If not TLV, return 303 redirect to `/api2/*`.
+2. **Worker (`/api2/*`)**: Runs with placement `region = "azure:israelcentral"`, forcing execution at TLV regardless of the user's edge location.
+
+The client detects the redirect via `resp.url` and permanently switches to `/api2/` for the rest of the session. This way the Worker only serves the small minority of non-TLV users.
 
 #### Placement investigation notes
 
@@ -65,7 +71,7 @@ Several placement strategies were tested before finding a working solution:
 
 ### Edge caching
 
-The Worker uses the Cloudflare Cache API (`caches.default`) with `s-maxage=1` to cache Oref responses at each edge for 1 second. This reduces redundant fetches when many clients poll simultaneously. The browser cache uses `max-age=2` (matching the previous behavior).
+Both the Pages Functions and the Worker use the Cloudflare Cache API (`caches.default`) with `s-maxage=1` to cache Oref responses at each edge for 1 second. This reduces redundant fetches when many clients poll simultaneously. The browser cache uses `max-age=2` (matching the previous behavior).
 
 ## Alert Classification
 
@@ -134,4 +140,4 @@ Web Audio API oscillator-based sounds (no external files). Muted by default. Two
 cd worker && npx wrangler deploy  # deploy API proxy Worker
 ```
 
-The Pages project serves static assets. The Worker handles `/api/*` via a Workers route on `oref-map.org`. The `oref-map.pages.dev` → `oref-map.org` redirect is configured as a Cloudflare Redirect Rule (dashboard).
+The Pages project serves static assets and Pages Functions (`/api/*`). The Worker handles `/api2/*` via a Workers route on `oref-map.org`, serving as a fallback for non-TLV users.

--- a/functions/api/alarms-history.js
+++ b/functions/api/alarms-history.js
@@ -1,0 +1,43 @@
+const TARGET = 'https://alerts-history.oref.org.il//Shared/Ajax/GetAlarmsHistory.aspx?lang=he&mode=1';
+const OREF_HEADERS = {
+  'Referer': 'https://www.oref.org.il/',
+  'X-Requested-With': 'XMLHttpRequest',
+};
+
+export async function onRequestGet(context) {
+  const colo = context.request.cf?.colo || '';
+
+  if (colo !== 'TLV') {
+    return new Response(null, {
+      status: 303,
+      headers: { 'Location': '/api2/alarms-history', 'X-CF-Colo': colo },
+    });
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(context.request.url, { method: 'GET' });
+
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    const resp = new Response(cached.body, cached);
+    resp.headers.set('X-CF-Colo', colo);
+    return resp;
+  }
+
+  const resp = await fetch(TARGET, { headers: OREF_HEADERS });
+  const body = await resp.arrayBuffer();
+
+  const response = new Response(body, {
+    status: resp.status,
+    headers: {
+      'Content-Type': resp.ok ? 'application/json; charset=utf-8' : (resp.headers.get('Content-Type') || 'text/plain'),
+      'Cache-Control': 's-maxage=1, max-age=2',
+      'X-CF-Colo': colo,
+      'X-Served-By': 'pages-function',
+    },
+  });
+
+  if (resp.ok) context.waitUntil(cache.put(cacheKey, response.clone()));
+
+  return response;
+}

--- a/functions/api/alerts.js
+++ b/functions/api/alerts.js
@@ -1,0 +1,43 @@
+const TARGET = 'https://www.oref.org.il/warningMessages/alert/Alerts.json';
+const OREF_HEADERS = {
+  'Referer': 'https://www.oref.org.il/',
+  'X-Requested-With': 'XMLHttpRequest',
+};
+
+export async function onRequestGet(context) {
+  const colo = context.request.cf?.colo || '';
+
+  if (colo !== 'TLV') {
+    return new Response(null, {
+      status: 303,
+      headers: { 'Location': '/api2/alerts', 'X-CF-Colo': colo },
+    });
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(context.request.url, { method: 'GET' });
+
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    const resp = new Response(cached.body, cached);
+    resp.headers.set('X-CF-Colo', colo);
+    return resp;
+  }
+
+  const resp = await fetch(TARGET, { headers: OREF_HEADERS });
+  const body = await resp.arrayBuffer();
+
+  const response = new Response(body, {
+    status: resp.status,
+    headers: {
+      'Content-Type': resp.ok ? 'application/json; charset=utf-8' : (resp.headers.get('Content-Type') || 'text/plain'),
+      'Cache-Control': 's-maxage=1, max-age=2',
+      'X-CF-Colo': colo,
+      'X-Served-By': 'pages-function',
+    },
+  });
+
+  if (resp.ok) context.waitUntil(cache.put(cacheKey, response.clone()));
+
+  return response;
+}

--- a/functions/api/history.js
+++ b/functions/api/history.js
@@ -1,0 +1,43 @@
+const TARGET = 'https://www.oref.org.il/warningMessages/alert/History/AlertsHistory.json';
+const OREF_HEADERS = {
+  'Referer': 'https://www.oref.org.il/',
+  'X-Requested-With': 'XMLHttpRequest',
+};
+
+export async function onRequestGet(context) {
+  const colo = context.request.cf?.colo || '';
+
+  if (colo !== 'TLV') {
+    return new Response(null, {
+      status: 303,
+      headers: { 'Location': '/api2/history', 'X-CF-Colo': colo },
+    });
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(context.request.url, { method: 'GET' });
+
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    const resp = new Response(cached.body, cached);
+    resp.headers.set('X-CF-Colo', colo);
+    return resp;
+  }
+
+  const resp = await fetch(TARGET, { headers: OREF_HEADERS });
+  const body = await resp.arrayBuffer();
+
+  const response = new Response(body, {
+    status: resp.status,
+    headers: {
+      'Content-Type': resp.ok ? 'application/json; charset=utf-8' : (resp.headers.get('Content-Type') || 'text/plain'),
+      'Cache-Control': 's-maxage=1, max-age=2',
+      'X-CF-Colo': colo,
+      'X-Served-By': 'pages-function',
+    },
+  });
+
+  if (resp.ok) context.waitUntil(cache.put(cacheKey, response.clone()));
+
+  return response;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -508,6 +508,17 @@ html, body { height: 100%; font-family: Arial, sans-serif; }
   // Set PROXY_BASE to the Cloudflare Worker URL for production, e.g.:
   //   var PROXY_BASE = 'https://oref-proxy.YOUR_ACCOUNT.workers.dev';
   var PROXY_BASE = '';
+  var apiPrefix = '/api'; // Pages Function; switches to '/api2' (Worker) if non-TLV
+
+  function apiFetch(endpoint) {
+    return fetch(PROXY_BASE + apiPrefix + '/' + endpoint).then(function(resp) {
+      if (apiPrefix === '/api' && resp.url && resp.url.indexOf('/api2/') !== -1) {
+        console.log('Non-TLV colo detected, switching to /api2');
+        apiPrefix = '/api2';
+      }
+      return resp;
+    });
+  }
   var LIVE_POLL_MS = 1000;
   var HISTORY_POLL_MS = 10000;
   var GREEN_FADE_MS = 120000; // 2 minutes
@@ -1225,7 +1236,7 @@ html, body { height: 100%; font-family: Arial, sans-serif; }
   }
 
   function fetchLiveAlerts() {
-    fetch(PROXY_BASE + '/api/alerts')
+    apiFetch('alerts')
       .then(function(resp) {
         lastCfColo = resp.headers.get('X-CF-Colo') || lastCfColo;
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
@@ -1251,7 +1262,7 @@ html, body { height: 100%; font-family: Arial, sans-serif; }
   }
 
   function fetchHistory(onDone) {
-    fetch(PROXY_BASE + '/api/history')
+    apiFetch('history')
       .then(function(resp) {
         lastCfColo = resp.headers.get('X-CF-Colo') || lastCfColo;
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
@@ -1318,7 +1329,7 @@ html, body { height: 100%; font-family: Arial, sans-serif; }
 
   // --- Extended history (timeline) ---
   function fetchExtendedHistory(onDone) {
-    fetch(PROXY_BASE + '/api/alarms-history')
+    apiFetch('alarms-history')
       .then(function(resp) {
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
         return resp.json();

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -4,9 +4,9 @@ const OREF_HEADERS = {
 };
 
 const ROUTES = {
-  '/api/alerts': 'https://www.oref.org.il/warningMessages/alert/Alerts.json',
-  '/api/history': 'https://www.oref.org.il/warningMessages/alert/History/AlertsHistory.json',
-  '/api/alarms-history': 'https://alerts-history.oref.org.il//Shared/Ajax/GetAlarmsHistory.aspx?lang=he&mode=1',
+  '/api2/alerts': 'https://www.oref.org.il/warningMessages/alert/Alerts.json',
+  '/api2/history': 'https://www.oref.org.il/warningMessages/alert/History/AlertsHistory.json',
+  '/api2/alarms-history': 'https://alerts-history.oref.org.il//Shared/Ajax/GetAlarmsHistory.aspx?lang=he&mode=1',
 };
 
 export default {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2024-01-01"
 workers_dev = true
 
 [[routes]]
-pattern = "oref-map.org/api/*"
+pattern = "oref-map.org/api2/*"
 zone_name = "oref-map.org"
 
 [placement]


### PR DESCRIPTION
## Summary

- Pages Functions at `/api/*` serve TLV-routed users directly (free tier), reducing Worker invocations
- Non-TLV users get a 303 redirect to `/api2/*`, handled by the placement-pinned Worker
- Client detects the redirect via `resp.url` and switches to `/api2` permanently for the session
- Adds Worker deploy job to the GitHub Actions workflow

## Deployment

Deploy Pages first (adds Functions), then Worker (switches route to `/api2/*`). Both are handled by the CI workflow on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a two-tier API proxy architecture: direct service for Israel (TLV) users and automatic geographic routing for others.
  * Added intelligent caching layer for improved performance and reduced latency.

* **Documentation**
  * Updated architecture documentation to reflect the new two-tier proxy setup and geographic routing strategy.

* **Chores**
  * Separated deployment workflow for Pages and Worker services to enable parallel deployments.
  * Restructured API paths to support geographic-aware traffic routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->