### PR TITLE
Make last-alert status text clickable to show timeline

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1549,9 +1549,8 @@ html, body { height: 100%; font-family: Arial, sans-serif; }
         return;
       }
       if (!isOpen()) openTimeline();
-      for (var i = computedBands.length - 1; i >= 0; i--) {
-        seekTo(computedBands[i].center);
-        return;
+      if (computedBands.length > 0) {
+        seekTo(computedBands[computedBands.length - 1].center);
       }
     };
 


### PR DESCRIPTION
## Summary
- The "התרעה אחרונה לפני X דקות" text in the status bar is now an underlined clickable link
- Clicking it opens the timeline slider panel and seeks directly to the most recent alert event
- Reuses existing timeline infrastructure — no new UI components

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Last alert in the status area is now clickable, enabling quick navigation to the most recent alert in the timeline.
  * Status display now renders interactive alert links when a recent alert exists.

* **Style**
  * Link styling added for the last-alert link to match the app’s underlined, inherited-color link appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->