### PR TITLE
Increase polygon transparency for better map readability

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -952,7 +952,10 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     var polygon = idx != null ? cityPolygons[idx] : null;
     if (!polygon) return;
 
-    var opacity = state === 'green' ? 0.5 : 0.3;
+    var now = Date.now();
+    var opacity = state === 'green'
+      ? 0.5 * Math.max(0, 1 - ((now - (since || now)) / GREEN_FADE_MS))
+      : 0.3;
     polygon.setStyle({
       color: COLORS[state],
       fillColor: COLORS[state],


### PR DESCRIPTION
## Summary
- Reduce fill opacity for active alerts (red/purple/yellow) from 0.5 to 0.3, making map features visible underneath
- Reduce red polygon border weight from 1 to 0.5 for softer appearance
- Lower hover/active state opacity and stroke width for consistency
- Adjust green fade and stroke opacity offsets across all code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced fill and stroke opacities across polygons and markers for a lighter visual theme
  * Slightly thinner strokes and softened stroke opacity for clearer visuals
  * Tuned fade and animation math for smoother green fade-outs and transitions
  * Lowered emphasis on red-state rendering to de-prioritize visual weight
  * Adjusted pulse/hint and timeline restoration to preserve updated transparency behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->