### PR TITLE
Add zoom-to-alerts link on active alert status

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -84,7 +84,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
 .indicator-green  { background: #00cc00; }
 .indicator-err    { background: #999; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-#lastAlertLink { color: inherit; text-decoration: underline; cursor: pointer; }
+#lastAlertLink, #zoomAlertsLink { color: inherit; text-decoration: underline; cursor: pointer; }
 
 #errorDetail {
   display: none;
@@ -1229,6 +1229,18 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     return '';
   }
 
+  function zoomToActiveAlerts() {
+    var points = [];
+    for (var name in locationStates) {
+      if (locationStates[name].state !== 'green' && citiesGeo[name]) {
+        points.push(citiesGeo[name]);
+      }
+    }
+    if (points.length === 0) return;
+    var bounds = L.latLngBounds(points);
+    map.fitBounds(bounds, { padding: [50, 50], maxZoom: 12 });
+  }
+
   function updateLiveStatus() {
     if (!isLiveMode) return;
     var dominant = null, bestP = -1;
@@ -1241,7 +1253,15 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       }
     }
     if (dominant) {
-      setStatus(dominant, 'התרעות פעילות');
+      setStatusHTML(dominant, '<a href="#" id="zoomAlertsLink">התרעות פעילות</a>');
+      var zoomLink = document.getElementById('zoomAlertsLink');
+      if (zoomLink) {
+        zoomLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          zoomToActiveAlerts();
+        });
+      }
     } else {
       var rel = formatRelativeTime(lastDangerTime);
       if (rel) {


### PR DESCRIPTION
## Summary
- Makes the "התרעות פעילות" status text a clickable link when alerts are active
- Clicking it calls `map.fitBounds()` on all active (non-green) alert locations with padding
- Helps users quickly spot alerts in small/remote areas (e.g. northern border)

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clickable link in the status display that automatically zooms and centers the map to show all locations with active alerts. Users can now quickly navigate to affected areas without manual map adjustment.

* **Style**
  * Updated and extended styling for alert-related links in the status display to ensure consistent appearance across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->