### PR TITLE
Allow map interaction while timeline is open

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2121,11 +2121,6 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       closeSoundPanel();
       closed = true;
     }
-    var tlBtn = document.getElementById('timeline-btn');
-    if (tlBtn && tlBtn.classList.contains('open') && !tlBtn.contains(e.target)) {
-      closeTimelinePanel();
-      closed = true;
-    }
     if (closed) popPanelHistory();
     if (openPopupName) {
       var mapContainer = document.getElementById('map');


### PR DESCRIPTION
## Summary
- Stop closing the timeline panel when clicking/tapping the map
- Users can now pan and zoom to inspect historical alerts without losing the timeline view
- Timeline can still be closed via its button, Escape key, or mobile back button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline panel no longer automatically closes when clicking outside it

<!-- end of auto-generated comment: release notes by coderabbit.ai -->