### PR TITLE
Hide user location marker outside Israel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -597,6 +597,10 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       watching = true;
       navigator.geolocation.watchPosition(function(pos) {
         var latlng = [pos.coords.latitude, pos.coords.longitude];
+        if (!pointInRing(latlng, ISRAEL_CLIP_RING)) {
+          if (userLocationMarker) { map.removeLayer(userLocationMarker); userLocationMarker = null; }
+          return;
+        }
         if (!userLocationMarker) {
           userLocationMarker = L.marker(latlng, {
             icon: icon,
@@ -859,6 +863,21 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     [34.98, 29.55],   // Near Eilat
     [34.92, 29.49]    // Close polygon
   ];
+
+  // Ray-casting point-in-polygon test. ring is [lng, lat] pairs.
+  function pointInRing(latlng, ring) {
+    var lng = latlng[1], lat = latlng[0];
+    var inside = false;
+    for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      var xi = ring[i][0], yi = ring[i][1];
+      var xj = ring[j][0], yj = ring[j][1];
+      if ((yi > lat) !== (yj > lat) &&
+          lng < (xj - xi) * (lat - yi) / (yj - yi) + xi) {
+        inside = !inside;
+      }
+    }
+    return inside;
+  }
 
   function clipToIsrael(latlngs) {
     // Convert [lat, lng] ring to [lng, lat] for polygon-clipping


### PR DESCRIPTION
## Summary
- Add `pointInRing` ray-casting point-in-polygon utility that tests if a `[lat, lng]` point is inside a `[lng, lat]` ring
- Skip displaying the user location marker when GPS coordinates fall outside `ISRAEL_CLIP_RING` (e.g. due to GPS errors placing the user in the sea)
- Remove the marker if the position drifts outside Israel after previously being shown

Fixes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geolocation accuracy by adding boundary validation. The app now prevents location markers from being displayed outside designated service areas, ensuring only valid positions are shown on the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->