### PR TITLE
Improve timeline slider UX and alignment

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1874,6 +1874,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       else computeEventPeaks();
       stopPlay();
       if (eventPeaks.length > 0) seekTo(eventPeaks[eventPeaks.length - 1]);
+      else seekTo(timelineMax);
     };
 
     btnRow.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- Align color bar with slider thumb travel range (inset by 8px each side)
- Custom-style the slider: light blue track, house-shaped (pentagon) thumb pointing up toward the color bar
- History button now opens on the biggest event (most unique locations) instead of the latest
- "התרעה אחרונה" link correctly navigates to the last event whether the history panel is open or closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline now selects and seeks to the peak event with the largest number of unique locations; peak-size, start, and group data improve navigation and auto-seeking.
  * Locate button toggles between zooming to the current/biggest event and resetting to the default view.
  * Playback auto-zooms to event-group bounds during play while avoiding interference with manual user moves; peak-driven timeline rendering added.

* **Style**
  * Improved timeline slider and tick styling, focus outlines, and thumb appearance for better layout and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->