### PR TITLE
Add proxy resilience: auto-reset on error and periodic re-check

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -615,8 +615,22 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
   var PROXY_BASE = '';
   var apiPrefix = '/api'; // Pages Function; switches to '/api2' (Worker) if non-TLV
 
+  function resetProxy() {
+    PROXY_BASE = '';
+    apiPrefix = '/api';
+  }
+
   function apiFetch(endpoint) {
-    return fetch(PROXY_BASE + apiPrefix + '/' + endpoint).then(function(resp) {
+    var url = PROXY_BASE + apiPrefix + '/' + endpoint;
+    var wasProxy = apiPrefix === '/api2';
+
+    return fetch(url).then(function(resp) {
+      if (!resp.ok && wasProxy) { resetProxy(); }
+      return resp;
+    }, function(err) {
+      if (wasProxy) { resetProxy(); }
+      return Promise.reject(err);
+    }).then(function(resp) {
       if (apiPrefix === '/api' && resp.url && resp.url.indexOf('/api2/') !== -1) {
         var u = new URL(resp.url);
         PROXY_BASE = u.origin !== location.origin ? u.origin : '';
@@ -626,6 +640,9 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       return resp;
     });
   }
+
+  // Periodically reset proxy so client can re-check if direct /api works
+  setInterval(resetProxy, 300000); // 5 min
   var LIVE_POLL_MS = 1000;
   var HISTORY_POLL_MS = 10000;
   var GREEN_FADE_MS = 120000; // 2 minutes


### PR DESCRIPTION
## Summary
- Reset proxy selection when a fetch fails (error or non-ok response), so the next poll (within 1s) retries via `/api` and gets a fresh redirect to a different proxy
- Periodically reset every 5 minutes so users temporarily routed to non-TLV colos by Cloudflare recover automatically instead of staying on a proxy permanently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API request resilience with automatic fallback to direct connectivity when issues are detected.
  * Improved error recovery: the system now automatically reverts to direct API communication on failures.
  * Added periodic system health checks to maintain optimal connectivity and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->