### PR TITLE
fill 15-30 min gap in today's timeline

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1879,8 +1879,6 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
           .then(function(resp) {
             if (resp.status === 404) {
               console.log('No day-history data for', dateParam);
-              dayHistoryReady = true;
-              if (onDone) onDone();
               return;
             }
             if (!resp.ok) throw new Error('HTTP ' + resp.status);
@@ -1889,7 +1887,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     )
       .then(function(entries) {
         if (!entries) return; // 404 case already handled
-        if (!Array.isArray(entries)) { dayHistoryReady = true; if (onDone) onDone(); return; }
+        if (!Array.isArray(entries)) return;
         processEntries(entries);
 
         // Gap-fill: when viewing today, fetch extended history API


### PR DESCRIPTION
## Summary
- On page load (today only), fetch `/api/alarms-history` alongside R2 day-history to fill the ~15-30 min gap caused by ingestion cron lag
- Decouple timeline data loading from the init sequence so the page becomes interactive faster
- Gap-fill failure is non-fatal — falls back to R2 data only

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background prefetching of the previous day's history to speed timeline loading
  * Asynchronous gap-fill fetch for current-day late entries (non-fatal on failures)

* **Bug Fixes & Improvements**
  * Improved caching, deduplication, validation and normalization of historical entries
  * More reliable and consistent timeline initialization and completion sequencing (ensures single completion callback)
  * Silent handling of transient network/parse errors to avoid interrupting timeline loading
<!-- end of auto-generated comment: release notes by coderabbit.ai -->