### PR TITLE
fix initial status showing green before first fetch

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1800,7 +1800,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
           setStatus('err', 'תקלה בטעינת התרעות קודמות. מנסה שוב...');
         }
         console.error('History fetch error:', err);
-        if (onDone) onDone();
+        if (onDone) setTimeout(function() { fetchHistory(onDone); }, 1000);
       });
   }
 


### PR DESCRIPTION
## Summary
- Guard `updateLiveStatus()` with `initialized` flag so it's a no-op until the first successful history fetch completes
- Removes the premature `updateLiveStatus()` call during init that was overwriting "מתחבר..." with "אין התרעות פעילות" before any data was fetched

## Test plan
- Disconnect from network, do a regular refresh (Cmd-R) — should show "מתחבר..." with gray dot instead of green "no alerts"
- Reconnect — status should update normally after first fetch completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented status updates before initialization to ensure accurate UI during startup.
  * Deferred live-status checks until initialization completes, avoiding premature UI changes.
  * Added automatic retry for history fetch failures, improving resilience on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->