### PR TITLE
Fix cross-midnight timeline gap; tighten ingestion window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ cd worker && npx wrangler deploy   # deploy API proxy Worker
 - `functions/api/` — Pages Functions: proxy for TLV users, 303 redirect for non-TLV
 - `worker/src/index.js` — Cloudflare Worker: fallback proxy for non-TLV users (placement: `azure:israelcentral`)
 - `worker/wrangler.toml` — Worker configuration with placement and `/api2/*` route
+- `ingestion/src/index.js` — Cloudflare Worker cron: ingests extended history API into R2 day-history files
+- `tools/backfill_history.py` — One-off script to rebuild R2 day-history files from the oref API (mode=3, city by city)
+- `tools/poll-coderabbit.sh` — Polls CodeRabbit review status on a PR via GitHub commit status API
 - `docs/map-requirements.md` — Feature requirements doc
 
 ## Oref API details
@@ -46,7 +49,7 @@ cd worker && npx wrangler deploy   # deploy API proxy Worker
 - `data` is a **string** (single location), unlike the live API.
 - `alertDate` format: `"YYYY-MM-DD HH:MM:SS"`
 - Reliable record of all alerts including all-clears. Use this to reconstruct current state on page load.
-- Also feeds into the timeline's `extendedHistory` to fill the R2 day-history lag (~15-30 min).
+- Also feeds into the timeline's `extendedHistory` to fill the R2 day-history lag (~3-18 min).
 
 ### Category numbers are unreliable
 Do **not** use `cat`/`category` for classification — the same number is reused for different alert types across the two APIs. Always classify by **title text**.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,10 +179,11 @@ The Oref extended history API only exposes the latest ~3,000 entries (~1–2 hou
 
 ### Storage format
 
-Each day is stored as two R2 objects:
+Each day is stored as a single R2 object:
 
-- **`YYYY-MM-DD.jsonl`** — the data file, comma-per-line JSONL
-- **`YYYY-MM-DD.complete`** — empty marker; presence means the day is fully ingested
+- **`YYYY-MM-DD.jsonl`** — comma-per-line JSONL
+
+Each day file covers events from `(D-1)T23:00` to `DT22:59` (Israel time). Events with `alertDate` hour ≥ 23 are stored in the **next** day's file. This ensures that just after midnight, today's R2 file already contains yesterday's late-night events.
 
 Each entry occupies one line ending with `,\n`:
 
@@ -203,26 +204,29 @@ For an empty file this produces `'[]'` — valid JSON.
 
 A Cloudflare Worker with a cron trigger every 15 minutes (at `:03`, `:18`, `:33`, `:48`).
 
-**Time window logic**: Each run is responsible for a fixed, non-overlapping 15-minute window derived from `event.scheduledTime` (not wall clock):
+**Time window logic**: Each run ingests a fixed 15-minute quarter-hour block, determined by wall clock time (Israel time). The cron fires 3 minutes after each quarter ends, giving the API time to populate entries:
 
-```
-window = [scheduledTime - 30min,  scheduledTime - 15min)
-```
+| Actual minute (Israel) | Window ingested |
+|---|---|
+| :01–:13 | [XX:45, XX+1:00) |
+| :17–:28 | [XX:00, XX:15) |
+| :32–:43 | [XX:15, XX:30) |
+| :47–:58 | [XX:30, XX:45) |
+| :14–:16, :29–:31, :44–:46, :59–:00 | **Dead zone** — skip |
 
-Windows are contiguous — the next run's window starts exactly where the previous ended. Using `event.scheduledTime` means retries or delayed execution don't corrupt window boundaries.
-
-**`scheduledTime` has non-zero seconds**: Despite being a cron trigger, `event.scheduledTime` can include seconds (e.g., `:03:39` instead of `:03:00`). Since oref `alertDate` values always have `:00` seconds, the string comparison `>=`/`<` would misalign window boundaries. The code snaps `scheduledTime` to the nearest cron schedule point (minutes 3, 18, 33, 48) to ensure clean `:00` second boundaries.
+If the worker runs in a dead zone (ambiguous timing between two cron points), it logs and exits without processing. This handles cron drift safely.
 
 **Israel time conversion**: `alertDate` values from the API are in Israel time. Window bounds (UTC timestamps) are converted using `Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Jerusalem' })` for string comparison.
+
+**R2 date key**: Events are grouped by `r2DateKey(alertDate)` — events with hour ≥ 23 go to the next day's file (see [Storage format](#storage-format)).
 
 **Processing**:
 1. Fetch from proxy1 Worker (`/api2/alarms-history`) — see [why proxy1](#why-proxy1-not-history-proxy) below
 2. Strip BOM, parse JSON (~3,000 entries, ~50KB)
 3. Filter to entries within the time window
 4. Map to 4 fields: `{ data, alertDate, category_desc, rid }`
-5. Sort by `alertDate`, group by date
+5. Sort by `alertDate`, group by R2 date key (events 23:xx → next day's file)
 6. For each date: read existing `.jsonl` from R2, append new entries, write back
-7. At midnight crossing (`startDate < endDate`): write `.complete` marker for the completed day
 
 **Observability**: `[observability] enabled = true` in wrangler.toml persists logs to the Cloudflare dashboard. Console logs include window boundaries, entry counts, and R2 write details for each cron run.
 
@@ -236,7 +240,7 @@ Pages Function serving R2 data as JSON.
 - Validates date format, returns 400 if invalid
 - Reads `YYYY-MM-DD.jsonl` from R2, returns 404 if not found
 - Converts comma-per-line JSONL to JSON array
-- **Caching**: completed days (`.complete` exists) → `max-age=3600` (1 hour); ongoing days → `max-age=60` (1 minute)
+- **Caching**: past days (`date < today`) → `max-age=3600` (1 hour); today → `max-age=60` (1 minute)
 - **Local dev**: If `HISTORY_BUCKET` binding is absent, proxies to production
 
 ### Backfill script (`tools/backfill_history.py`)
@@ -251,7 +255,9 @@ uv run tools/backfill_history.py --today    # merge today first (no prompt), the
 
 **Interactive mode** (past dates): Downloads the existing R2 file for each date, compares `rid` sets, shows a diff summary, saves both versions to `tmp/backfill-compare/`, and prompts per date.
 
-**`--today` mode**: Merges backfill data with the existing R2 file for today (union by `rid`). Uses a **cron-aware cutoff** — only includes backfill entries before the last completed cron window boundary (`:03`, `:18`, `:33`, `:48`) to avoid creating duplicates when the next cron run appends. Prints a timing summary with margin to next cron. Does not write `.complete` (day is ongoing).
+**`--today` mode**: Merges backfill data with the existing R2 file for today (union by `rid`). Uses a **cron-aware cutoff** — only includes backfill entries before the last completed quarter-hour boundary (`:00`, `:15`, `:30`, `:45`, available 3 min after each) to avoid creating duplicates when the next cron run appends. Prints a timing summary with margin to next cron.
+
+Both modes use `r2_date_key()` to group events — entries with `alertDate` hour ≥ 23 go to the next day's file, matching the ingestion worker's partitioning.
 
 ### Why proxy1, not history-proxy
 

--- a/functions/api/day-history.js
+++ b/functions/api/day-history.js
@@ -11,10 +11,10 @@ export async function onRequestGet(context) {
     return fetch(`https://oref-map.org/api/day-history?date=${date}`);
   }
 
-  const complete = await context.env.HISTORY_BUCKET.head(`${date}.complete`);
+  const todayIsrael = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Jerusalem' }).format(new Date());
+
   const obj = await context.env.HISTORY_BUCKET.get(`${date}.jsonl`);
   if (!obj) {
-    const todayIsrael = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Jerusalem' }).format(new Date());
     if (date === todayIsrael) {
       return new Response('[]', {
         headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'public, max-age=60' },
@@ -26,8 +26,8 @@ export async function onRequestGet(context) {
   const text = await obj.text();
   const json = '[' + text.trimEnd().slice(0, -1) + ']';
 
-  // Completed days are immutable — cache for 1 hour. Ongoing days change every 15 min.
-  const cacheControl = complete ? 'public, max-age=3600' : 'public, max-age=60';
+  // Past days are immutable — cache for 1 hour. Today changes every 15 min.
+  const cacheControl = date < todayIsrael ? 'public, max-age=3600' : 'public, max-age=60';
 
   return new Response(json, {
     headers: {

--- a/ingestion/src/index.js
+++ b/ingestion/src/index.js
@@ -44,14 +44,51 @@ async function sendPushover(env, title, message) {
   });
 }
 
+// Map alertDate to R2 file date key. Events from 23:xx belong to next day's file.
+// Each day file covers (D-1)T23:00 to DT22:59.
+function r2DateKey(alertDateStr) {
+  const d = new Date(alertDateStr.slice(0, 10) + 'T12:00:00Z');
+  if (parseInt(alertDateStr.slice(11, 13)) >= 23)
+    d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// Determine the 15-minute ingestion window from wall time.
+// Returns { windowStartMs, windowEndMs } or null if in a dead zone.
+// Cron runs at :03, :18, :33, :48 but actual execution may drift.
+//   :01–:13 → [XX:45, XX+1:00)    :17–:28 → [XX:00, XX:15)
+//   :32–:43 → [XX:15, XX:30)      :47–:58 → [XX:30, XX:45)
+//   Dead zones: :14–:16, :29–:31, :44–:46, :59–:00
+function computeWindow(nowMs) {
+  const israelStr = toIsraelTimeStr(nowMs);
+  const minute = parseInt(israelStr.slice(14, 16));
+
+  // Map minute to window-end offset (minutes after the hour, Israel time)
+  let windowEndMinute;
+  if (minute >= 1 && minute <= 13) windowEndMinute = 0;       // [XX:45, XX+1:00)
+  else if (minute >= 17 && minute <= 28) windowEndMinute = 15; // [XX:00, XX:15)
+  else if (minute >= 32 && minute <= 43) windowEndMinute = 30; // [XX:15, XX:30)
+  else if (minute >= 47 && minute <= 58) windowEndMinute = 45; // [XX:30, XX:45)
+  else return null; // dead zone
+
+  // Compute window end by subtracting the offset from nowMs to reach :00/:15/:30/:45
+  // For windowEndMinute=0, subtract the full minute+seconds to reach the top of the hour
+  const seconds = parseInt(israelStr.slice(17, 19));
+  const offsetMinutes = windowEndMinute === 0 ? minute : minute - windowEndMinute;
+  const windowEndMs = nowMs - offsetMinutes * 60000 - seconds * 1000;
+  const windowStartMs = windowEndMs - 15 * 60000;
+
+  return { windowStartMs, windowEndMs };
+}
+
 export default {
   async scheduled(event, env, ctx) {
-    // Snap to nearest cron point (minutes 3, 18, 33, 48) — scheduledTime can drift by seconds
-    const rawMinutes = Math.floor(event.scheduledTime / 60000);
-    const scheduledTime = (Math.floor((rawMinutes - 3) / 15) * 15 + 3) * 60000;
-
-    const windowEndMs = scheduledTime - 15 * 60 * 1000;
-    const windowStartMs = scheduledTime - 30 * 60 * 1000;
+    const window = computeWindow(Date.now());
+    if (!window) {
+      console.log('Dead zone — skipping execution');
+      return;
+    }
+    const { windowStartMs, windowEndMs } = window;
 
     const windowStartStr = toIsraelTimeStr(windowStartMs);
     const windowEndStr = toIsraelTimeStr(windowEndMs);
@@ -83,10 +120,10 @@ export default {
 
     filtered.sort((a, b) => a.alertDate < b.alertDate ? -1 : a.alertDate > b.alertDate ? 1 : 0);
 
-    // Group by date
+    // Group by R2 date key (events 23:xx go to next day's file)
     const byDate = {};
     for (const e of filtered) {
-      const d = e.alertDate.slice(0, 10);
+      const d = r2DateKey(e.alertDate);
       if (!byDate[d]) byDate[d] = [];
       byDate[d].push(e);
     }
@@ -102,20 +139,6 @@ export default {
         httpMetadata: { contentType: 'application/jsonl' },
       });
       console.log(`Wrote ${d}.jsonl: ${dateEntries.length} new + ${existingText.length} bytes existing`);
-    }
-
-    // Midnight: write .complete marker for previous day when window crosses midnight
-    const startDate = windowStartStr.slice(0, 10);
-    const endDate = windowEndStr.slice(0, 10);
-    if (startDate < endDate) {
-      const completeKey = `${startDate}.complete`;
-      const existing = await env.HISTORY_BUCKET.head(completeKey);
-      if (!existing) {
-        await env.HISTORY_BUCKET.put(completeKey, '', {
-          httpMetadata: { contentType: 'text/plain' },
-        });
-        console.log(`Wrote ${completeKey}`);
-      }
     }
   },
 };

--- a/tools/backfill_history.py
+++ b/tools/backfill_history.py
@@ -39,6 +39,16 @@ HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
 }
 CONCURRENCY = 10
+
+
+def r2_date_key(alert_date: str) -> str:
+    """Map alertDate to R2 file date key. Events from 23:xx belong to next day's file."""
+    d = date.fromisoformat(alert_date[:10])
+    if int(alert_date[11:13]) >= 23:
+        d += timedelta(days=1)
+    return d.isoformat()
+
+
 RETRIES = 3
 RETRY_DELAYS = [2, 5, 15]
 WAR_START = "2026-02-28"
@@ -121,18 +131,6 @@ def wrangler_put(key: str, data: bytes, content_type: str) -> bool:
         Path(tmp_path).unlink(missing_ok=True)
 
 
-def wrangler_put_empty(key: str) -> bool:
-    result = subprocess.run(
-        ["npx", "wrangler", "r2", "object", "put", f"{BUCKET}/{key}",
-         "--pipe", "--content-type", "text/plain", "--remote"],
-        input=b"",
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        print(f"  UPLOAD FAIL {key}:\n{result.stderr.decode()}", file=sys.stderr)
-        return False
-    return True
-
 
 def merge_entries(backfill: list[dict], remote: list[dict]) -> list[dict]:
     """Union of both entry sets by rid, sorted by alertDate."""
@@ -188,21 +186,23 @@ async def main() -> None:
                 "category_desc": e["category_desc"],
                 "rid": rid,
             }
-            by_date.setdefault(alert_date[:10], []).append(entry)
+            by_date.setdefault(r2_date_key(alert_date), []).append(entry)
 
     total = sum(len(v) for v in by_date.values())
     print(f"  {total} unique entries across {len(by_date)} dates")
 
     # --today: merge today's data immediately (no prompt)
     if update_today:
-        # Cutoff = last completed cron window end. Cron window ends at :03, :18, :33, :48.
+        # Cutoff = last completed cron window end. Cron ingests quarter-hour blocks
+        # [XX:00, XX:15), [XX:15, XX:30), etc. — the quarter ending at :00/:15/:30/:45.
+        # Cron fires 3 min after each quarter ends, so if now >= :03, the :00 quarter is done.
         now = datetime.now()
-        cutoff_minutes = [3, 18, 33, 48]
-        candidates = [m for m in cutoff_minutes if m <= now.minute]
+        cutoff_minutes = [0, 15, 30, 45]
+        candidates = [m for m in cutoff_minutes if m + 3 <= now.minute]
         if candidates:
             cutoff_time = now.replace(minute=max(candidates), second=0, microsecond=0)
         else:
-            cutoff_time = (now - timedelta(hours=1)).replace(minute=48, second=0, microsecond=0)
+            cutoff_time = (now - timedelta(hours=1)).replace(minute=45, second=0, microsecond=0)
         cutoff_str = cutoff_time.strftime("%Y-%m-%dT%H:%M:%S")
         print(f"\nCutoff: {cutoff_str} (entries after this left to cron)")
 
@@ -297,11 +297,6 @@ async def main() -> None:
     for day, entries in to_upload:
         print(f"  Uploading {day}.jsonl ({len(entries)} entries)...")
         if not wrangler_put(f"{day}.jsonl", to_jsonl(entries).encode("utf-8"), "application/jsonl"):
-            failures.append(day)
-            continue
-
-        print(f"  Uploading {day}.complete...")
-        if not wrangler_put_empty(f"{day}.complete"):
             failures.append(day)
             continue
 

--- a/web/index.html
+++ b/web/index.html
@@ -1499,10 +1499,17 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     recordHistory(location, title, entry.alertDate || '', state);
 
     // Also feed into extendedHistory for timeline, but only if date matches the viewed day
+    // When viewing today, also accept yesterday's entries (cross-midnight: R2 day files
+    // cover 23:00 prev day to 22:59 current day, so history API entries from yesterday
+    // 23:xx belong on today's timeline)
     var entryDate = (entry.alertDate || '').slice(0, 10);
     var viewingDate = timelineDate || todayDateStr();
+    var yesterdayDate = new Date(viewingDate + 'T12:00:00Z');
+    yesterdayDate.setUTCDate(yesterdayDate.getUTCDate() - 1);
+    var yesterdayStr = yesterdayDate.toISOString().slice(0, 10);
+    var dateMatch = entryDate === viewingDate || (!timelineDate && entryDate === yesterdayStr);
     var key = location + '|' + (entry.alertDate || '').replace('T', ' ');
-    if (entryDate === viewingDate && !extendedRids.has(key) && since) {
+    if (dateMatch && !extendedRids.has(key) && since) {
       extendedRids.add(key);
       extendedHistory.push({ location: location, title: title, alertDate: since, state: state });
       if (!timelineMin || since < timelineMin) timelineMin = since;
@@ -2031,6 +2038,18 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
     };
 
     function switchDate(newDate) {
+      // Carry forward: when navigating backward, save entries from target day's
+      // 23:00-23:59 window (they came from the current day's R2 file and would be
+      // lost when we clear extendedHistory)
+      var carryover = [];
+      if (newDate < (timelineDate || todayDateStr())) {
+        var carryStart = new Date(newDate + 'T23:00:00').getTime();
+        var carryEnd = new Date(newDate + 'T23:59:59.999').getTime();
+        carryover = extendedHistory.filter(function(e) {
+          return e.alertDate >= carryStart && e.alertDate <= carryEnd;
+        });
+      }
+
       dayHistoryReady = false;
       extendedHistory = [];
       extendedRids = new Set();
@@ -2045,6 +2064,21 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
       label.style.opacity = '0.5';
       ticksEl.innerHTML = '';
 
+      function mergeCarryover() {
+        // Carryover entries are from newDate 23:00-23:59. The R2 file for newDate
+        // covers (newDate-1) 23:00 to newDate 22:59 — no overlap, so no dedup needed.
+        for (var i = 0; i < carryover.length; i++) {
+          extendedHistory.push(carryover[i]);
+        }
+        if (carryover.length > 0) {
+          extendedHistory.sort(function(a, b) { return a.alertDate - b.alertDate; });
+          if (extendedHistory.length > 0) {
+            timelineMin = extendedHistory[0].alertDate;
+            timelineMax = extendedHistory[extendedHistory.length - 1].alertDate;
+          }
+        }
+      }
+
       if (isViewingToday()) {
         // Restart history polling
         if (!historyPollId) {
@@ -2052,6 +2086,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
         }
         fetchHistory();
         fetchExtendedHistory(function() {
+          mergeCarryover();
           rebuildTimeline('first');
           prefetchPrevDay();
         });
@@ -2062,6 +2097,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
           historyPollId = null;
         }
         fetchExtendedHistory(function() {
+          mergeCarryover();
           rebuildTimeline('first');
           prefetchPrevDay();
         });


### PR DESCRIPTION
## Summary

- R2 day files now cover 23:00(prev) to 22:59(current) — late-night events appear on the correct day's timeline
- Ingestion window tightened from [t-30, t-15) to wall-clock quarter-hour blocks with 3-min buffer and dead zones for drift
- Removed `.complete` marker — caching uses `date < today` comparison instead
- Client accepts yesterday's history entries when viewing today, carries forward 23:xx events when navigating backward
- Updated CLAUDE.md structure section, architecture.md, and backfill script

## After merge

1. Run `uv run tools/backfill_history.py` to rebuild R2 files with new partitioning
2. Optionally clean up old `.complete` markers from R2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timeline handling for late-night entries that span multiple dates.
  * Improved cache behavior for the History API with better date-based logic.

* **Improvements**
  * Refined data storage format for more efficient R2 handling.
  * Enhanced ingestion timing with improved wall-clock-based window control.

* **Documentation**
  * Updated architecture documentation to reflect new storage and caching semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->