### PR TITLE
Add favorite locations and improve ingestion retry

### DIFF
--- a/ingestion/src/index.js
+++ b/ingestion/src/index.js
@@ -109,7 +109,7 @@ export default {
       ctx.waitUntil(sendPushover(
         env,
         'oref-map ingestion failure',
-        `Failed to fetch oref history after ${RETRY_DELAYS_MS.length + 1} retries (~8 min). Window: ${windowStartStr} – ${windowEndStr}\nError: ${e.message}`
+        `Failed to fetch oref history after ${RETRY_DELAYS_MS.length} retries (~${Math.round(RETRY_DELAYS_MS.reduce((a, b) => a + b, 0) / 60000)} min). Window: ${windowStartStr} – ${windowEndStr}\nError: ${e.message}`
       ));
       return;
     }

--- a/web/index.html
+++ b/web/index.html
@@ -1418,9 +1418,10 @@ body.idle #right-panel {
     }
   }
 
-  // Expose for popup onclick
-  window._toggleFav = function(name) {
-    // Use stored click latlng, or fall back to existing favorite position
+  // Expose for popup onclick — uses openPopupName so no name is embedded in HTML
+  window._toggleFav = function() {
+    var name = openPopupName;
+    if (!name) return;
     var latlng = openPopupLatlng || favorites[name];
     if (!latlng) return;
     toggleFavorite(name, latlng);
@@ -1442,7 +1443,7 @@ body.idle #right-panel {
     var isFav = !!favorites[name];
     var starColor = isFav ? '#f5a623' : '#ccc';
     var starChar = isFav ? '\u2605' : '\u2606';
-    var starBtn = '<span class="fav-star" onclick="window._toggleFav(\'' + name.replace(/'/g, "\\'") + '\')" ' +
+    var starBtn = '<span class="fav-star" onclick="window._toggleFav()" ' +
       'style="cursor:pointer;font-size:18px;color:' + starColor + ';margin-inline-start:6px;vertical-align:middle" ' +
       'title="' + (isFav ? 'הסר ממועדפים' : 'הוסף למועדפים') + '">' + starChar + '</span>';
     return '<div style="direction:rtl;width:min(360px,85vw);text-align:right"><b>' + name + '</b>' + starBtn +


### PR DESCRIPTION
## Summary
- **Favorite locations**: Users can star locations from the popup to mark them as favorites. Starred locations show a small gold star marker on the map (white circle with shadow, matching the my-location dot). Favorites persist in localStorage across sessions.
- **Ingestion retry**: Extend retry delays from 3 attempts (~65s) to 7 attempts (~8 min) to better handle transient oref API failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent favorites: add/remove starred locations, persist across sessions, and show favorite markers and popup state when opened
  * Improved retry/error reporting: increased retry attempts and display of estimated total retry duration in failure notifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->