### PR TITLE
Add launch source prediction feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Beta/debug features are gated behind URL parameters with an `f-` prefix (e.g. `?
 - **CSS-only** (e.g. hiding a menu item): add `class="f-gated"` to the element, then add a CSS rule `body.f-<name> #element.f-gated { display: block !important; }`.
 - **JS-only**: check `if (FF.myfeature) { ... }`.
 
-**Current flags:** `f-log` (on-screen console overlay), `f-debugapi` (force API proxy host).
+**Current flags:** `f-log` (on-screen console overlay), `f-debugapi` (force API proxy host), `f-predict` (launch source prediction lines, experimental).
 
 ## Oref API details
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To run locally, see the [Development](#development) section above.
 
 ## Contributors
 
-Thanks to [@uripeer3](https://github.com/uripeer3), [@tomerkon](https://github.com/tomerkon), [@michalrymland](https://github.com/michalrymland), and [@ravitzm21](https://github.com/ravitzm21) for contributing to this project.
+Thanks to [@uripeer3](https://github.com/uripeer3), [@tomerkon](https://github.com/tomerkon), [@michalrymland](https://github.com/michalrymland), [@ravitzm21](https://github.com/ravitzm21), [@tomeras91](https://github.com/tomeras91), and [@talmiller2](https://github.com/talmiller2) for contributing to this project.
 
 ## Data
 

--- a/tests/prediction.test.js
+++ b/tests/prediction.test.js
@@ -10,6 +10,7 @@ function approx(a, b, tol) { return Math.abs(a - b) < (tol || 1e-6); }
 function section(name) { console.log('\n' + name); }
 
 // ── Extracted functions ──────────────────────────────────────────────
+// NOTE: Functions below are copied from web/prediction-mode.js. Keep in sync.
 
 function polygonArea(poly) {
   var rings = poly.getLatLngs();
@@ -36,58 +37,48 @@ function polygonCentroid(poly) {
   return [sumLat / outer.length, sumLng / outer.length];
 }
 
-function clusterPoints(points, eps, minPts) {
-  if (!minPts) minPts = 2;
-  var n = points.length;
-  var eps2 = eps * eps;
-  var labels = [];
-  for (var i = 0; i < n; i++) labels[i] = -1;
-  function neighbors(i) {
-    var nb = [];
-    for (var j = 0; j < n; j++) {
-      var dl = points[i][0] - points[j][0], dg = points[i][1] - points[j][1];
-      if (dl * dl + dg * dg <= eps2) nb.push(j);
-    }
-    return nb;
-  }
-  var cluster = 0;
+function clusterByAdjacency(locPoints, locationPolygons) {
+  var n = locPoints.length;
+  if (n === 0) return [];
+  var locVerts = [];
   for (var i = 0; i < n; i++) {
-    if (labels[i] !== -1) continue;
-    var nb = neighbors(i);
-    if (nb.length < minPts) { labels[i] = -2; continue; }
-    labels[i] = cluster;
-    var queue = nb.slice(), qi = 0;
-    while (qi < queue.length) {
-      var j = queue[qi++];
-      if (labels[j] === -2) labels[j] = cluster;
-      if (labels[j] !== -1) continue;
-      labels[j] = cluster;
-      var jnb = neighbors(j);
-      if (jnb.length >= minPts) {
-        for (var k = 0; k < jnb.length; k++) queue.push(jnb[k]);
+    var poly = locationPolygons[locPoints[i][3]];
+    var verts = [];
+    if (poly) {
+      var rings = poly.getLatLngs();
+      var outer = Array.isArray(rings[0]) && rings[0].length && rings[0][0].lat !== undefined ? rings[0] : rings;
+      for (var j = 0; j < outer.length; j++) verts.push([outer[j].lat, outer[j].lng]);
+    }
+    locVerts.push(verts);
+  }
+  var parent = [];
+  for (var i = 0; i < n; i++) parent[i] = i;
+  function find(i) {
+    while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; }
+    return i;
+  }
+  var tol2 = 0.005 * 0.005;
+  for (var i = 0; i < n; i++) {
+    for (var j = i + 1; j < n; j++) {
+      if (find(i) === find(j)) continue;
+      var found = false;
+      for (var vi = 0; vi < locVerts[i].length && !found; vi++) {
+        for (var vj = 0; vj < locVerts[j].length && !found; vj++) {
+          var dl = locVerts[i][vi][0] - locVerts[j][vj][0];
+          var dg = locVerts[i][vi][1] - locVerts[j][vj][1];
+          if (dl * dl + dg * dg < tol2) {
+            parent[find(i)] = find(j);
+            found = true;
+          }
+        }
       }
     }
-    cluster++;
-  }
-  if (cluster === 0) return [];
-  for (var i = 0; i < n; i++) {
-    if (labels[i] >= 0) continue;
-    var best = Infinity, bestC = -1;
-    for (var j = 0; j < n; j++) {
-      if (labels[j] < 0) continue;
-      var dl = points[i][0] - points[j][0], dg = points[i][1] - points[j][1];
-      var d2 = dl * dl + dg * dg;
-      if (d2 < best) { best = d2; bestC = labels[j]; }
-    }
-    if (bestC < 0) continue;
-    labels[i] = bestC;
   }
   var groups = {};
   for (var i = 0; i < n; i++) {
-    var c = labels[i];
-    if (c < 0) continue;
-    if (!groups[c]) groups[c] = [];
-    groups[c].push(points[i]);
+    var root = find(i);
+    if (!groups[root]) groups[root] = [];
+    groups[root].push(locPoints[i]);
   }
   return Object.keys(groups).map(function(k) { return groups[k]; });
 }
@@ -235,50 +226,63 @@ section('polygonArea');
   assert(polygonArea(degen) === 0, 'degenerate polygon (2 points) = 0');
 })();
 
-section('clusterPoints (DBSCAN)');
+section('clusterByAdjacency — shared vertices');
 (function() {
-  // Two tight groups far apart
-  var pts = [[0, 0], [0.01, 0.01], [0.02, 0],   // group A near origin
-             [5, 5], [5.01, 5.01], [5.02, 5]];   // group B far away
-  var clusters = clusterPoints(pts, 0.35);
-  assert(clusters.length === 2, 'two distant groups → 2 clusters');
-
-  // All within threshold (chain connectivity)
-  var close = [[0, 0], [0.1, 0], [0.2, 0], [0.3, 0]];
-  var c2 = clusterPoints(close, 0.35);
-  assert(c2.length === 1, 'chain within threshold → 1 cluster');
-
-  // Single point: DBSCAN with minPts=2 cannot form a core point → noise → returns []
-  var single = [[1, 1]];
-  assert(clusterPoints(single, 0.35).length === 0, 'single point → 0 clusters (noise in DBSCAN)');
-
-  // Points just outside threshold should stay separate (each pair is noise)
-  var sep = [[0, 0], [0.5, 0]];
-  assert(clusterPoints(sep, 0.35).length === 0, 'two points beyond threshold → 0 clusters (both noise)');
-
-  // Three-element points (with weight) cluster by first two coords
-  var weighted = [[0, 0, 0.5], [0.1, 0, 0.8], [5, 5, 1.2]];
-  var c3 = clusterPoints(weighted, 0.35);
-  // [0,0] and [0.1,0] are within eps and form a core cluster; [5,5] is noise but
-  // cluster > 0 so it gets assigned to nearest cluster
-  assert(c3.length === 1, 'weighted: two close + one far → 1 cluster (far point assigned to nearest)');
-
-  // Two close pairs far from each other
-  var twoPairs = [[0, 0, 0.5], [0.1, 0, 0.8], [5, 5, 1.0], [5.1, 5, 1.2]];
-  var c4 = clusterPoints(twoPairs, 0.35);
-  assert(c4.length === 2, 'two close pairs far apart → 2 clusters');
+  // polyA and polyB share vertices at [30.1, 34.0] and [30.1, 34.1] → same cluster
+  var polyA = mockPoly([[30.0, 34.0], [30.1, 34.0], [30.1, 34.1], [30.0, 34.1]]);
+  var polyB = mockPoly([[30.1, 34.0], [30.2, 34.0], [30.2, 34.1], [30.1, 34.1]]);
+  var polyC = mockPoly([[31.0, 35.0], [31.1, 35.0], [31.1, 35.1], [31.0, 35.1]]);
+  var locPoints = [[30.05, 34.05, 1, 'A'], [30.15, 34.05, 1, 'B'], [31.05, 35.05, 1, 'C']];
+  var locationPolygons = { A: polyA, B: polyB, C: polyC };
+  var clusters = clusterByAdjacency(locPoints, locationPolygons);
+  assert(clusters.length === 2, 'adjacent pair + far one → 2 clusters (got ' + clusters.length + ')');
+  var sizes = clusters.map(function(c) { return c.length; }).sort(function(a, b) { return a - b; });
+  assert(sizes[0] === 1 && sizes[1] === 2, 'cluster sizes are [1, 2]');
 })();
 
-section('clusterPoints — all-noise guard');
+section('clusterByAdjacency — no shared vertices');
 (function() {
-  // All points isolated (no two within eps) → all noise → cluster count = 0 → returns []
-  var isolated = [[0, 0], [1, 1], [3, 3], [6, 6]];
-  var result = clusterPoints(isolated, 0.35);
-  assert(result.length === 0, 'all isolated points → empty array (all-noise guard)');
+  var polyA = mockPoly([[30.0, 34.0], [30.1, 34.0], [30.1, 34.1], [30.0, 34.1]]);
+  var polyB = mockPoly([[31.0, 35.0], [31.1, 35.0], [31.1, 35.1], [31.0, 35.1]]);
+  var locPoints = [[30.05, 34.05, 1, 'A'], [31.05, 35.05, 1, 'B']];
+  var clusters = clusterByAdjacency(locPoints, { A: polyA, B: polyB });
+  assert(clusters.length === 2, 'non-touching polygons → 2 clusters');
+})();
 
-  // Verify with single point as well
-  var one = [[10, 20]];
-  assert(clusterPoints(one, 0.5).length === 0, 'single isolated point → empty array');
+section('clusterByAdjacency — chain connectivity (transitive)');
+(function() {
+  // A touches B, B touches C → all three in one cluster
+  var polyA = mockPoly([[30.0, 34.0], [30.1, 34.0], [30.1, 34.1], [30.0, 34.1]]);
+  var polyB = mockPoly([[30.1, 34.0], [30.2, 34.0], [30.2, 34.1], [30.1, 34.1]]);
+  var polyC = mockPoly([[30.2, 34.0], [30.3, 34.0], [30.3, 34.1], [30.2, 34.1]]);
+  var locPoints = [[30.05, 34.05, 1, 'A'], [30.15, 34.05, 1, 'B'], [30.25, 34.05, 1, 'C']];
+  var clusters = clusterByAdjacency(locPoints, { A: polyA, B: polyB, C: polyC });
+  assert(clusters.length === 1, 'chain A→B→C → 1 cluster (got ' + clusters.length + ')');
+  assert(clusters[0].length === 3, 'cluster contains all 3 points');
+})();
+
+section('clusterByAdjacency — missing polygon');
+(function() {
+  // Location B has no polygon → B gets its own cluster (no shared vertices possible)
+  var polyA = mockPoly([[30.0, 34.0], [30.1, 34.0], [30.1, 34.1], [30.0, 34.1]]);
+  var locPoints = [[30.05, 34.05, 1, 'A'], [30.15, 34.05, 1, 'B']];
+  var clusters = clusterByAdjacency(locPoints, { A: polyA });
+  assert(clusters.length === 2, 'missing polygon → separate clusters');
+})();
+
+section('clusterByAdjacency — empty input');
+(function() {
+  assert(clusterByAdjacency([], {}).length === 0, 'empty input → empty output');
+})();
+
+section('clusterByAdjacency — near-miss tolerance');
+(function() {
+  // polyB's nearest vertex is 0.006° from polyA's vertex — just outside 0.005 tolerance
+  var polyA = mockPoly([[30.0, 34.0], [30.1, 34.0], [30.1, 34.1], [30.0, 34.1]]);
+  var polyB = mockPoly([[30.106, 34.0], [30.2, 34.0], [30.2, 34.1], [30.106, 34.1]]);
+  var locPoints = [[30.05, 34.05, 1, 'A'], [30.15, 34.05, 1, 'B']];
+  var clusters = clusterByAdjacency(locPoints, { A: polyA, B: polyB });
+  assert(clusters.length === 2, 'vertices 0.006° apart (> 0.005 tol) → separate clusters');
 })();
 
 section('fitLine — unweighted');

--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,6 @@
 <meta name="twitter:image" content="https://oref-map.org/og-image.jpg">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/prediction-mode.js"></script>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 html, body { height: 100%; font-family: Arial, sans-serif; }
@@ -234,6 +233,7 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
 }
 /* Feature-flag-gated elements: hidden by default, shown when flag is active */
 .f-gated { display: none !important; }
+body.f-predict #menu-predict.f-gated { display: block !important; }
 .menu-item { border-bottom: 1px solid #f0f0f0; }
 .menu-item:last-child { border-bottom: none; }
 .menu-item-row {
@@ -647,8 +647,8 @@ body.idle #right-panel {
         </button>
       </div>
       <div id="ext-menu">
-        <div id="menu-predict" class="menu-item">
-          <button class="menu-item-row" type="button">
+        <div id="menu-predict" class="menu-item f-gated">
+          <button class="menu-item-row" type="button" id="predict-enable-btn">
             <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L12 22M12 2L8 6M12 2L16 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="17" r="2" fill="currentColor"/><circle cx="8" cy="14" r="1.5" fill="currentColor" opacity="0.5"/><circle cx="16" cy="14" r="1.5" fill="currentColor" opacity="0.5"/></svg></span>
             <span class="menu-item-label">כיוון שיגור</span>
             <span class="menu-check"></span>
@@ -783,6 +783,29 @@ body.idle #right-panel {
     };
     document.head.appendChild(s);
   });
+
+  // Prediction: lazy-load on first enable or auto-load if previously enabled
+  (function() {
+    var loaded = false;
+    function load(atStartup) {
+      if (loaded) return;
+      loaded = true;
+      if (atStartup) _extPending++;
+      var s = document.createElement('script');
+      s.src = '/prediction-mode.js';
+      if (atStartup) {
+        s.onload = s.onerror = function() { _extPending--; _maybeDispatchReady(); };
+      } else {
+        try { localStorage.setItem('oref-predict', 'true'); } catch (e) {}
+        s.onerror = function() { loaded = false; try { localStorage.removeItem('oref-predict'); } catch (e) {} };
+      }
+      document.head.appendChild(s);
+    }
+    if (FF.predict) {
+      try { if (localStorage.getItem('oref-predict') === 'true') load(true); } catch (e) {}
+      document.getElementById('predict-enable-btn').addEventListener('click', function() { load(false); });
+    }
+  })();
 
   // --- Debug overlay (append console.warn/error to on-screen log when ?f-log) ---
   if (FF.log) {

--- a/web/prediction-mode.js
+++ b/web/prediction-mode.js
@@ -235,10 +235,13 @@
     }
 
     function updatePredictionLines() {
-      clearPredictionLines();
-      if (!enabled) return;
+      if (!enabled) {
+        clearPredictionLines();
+        return;
+      }
 
       ensureOrefPoints().then(function(orefPts) {
+        clearPredictionLines();
         var locationStates = A.locationStates;
         var locationPolygons = A.locationPolygons;
 
@@ -428,9 +431,8 @@
       });
     }
 
-    // Listen for state changes and escape
+    // Listen for state changes
     document.addEventListener('app:stateChanged', function() { sync(); });
-    document.addEventListener('app:escape', function() { clearPredictionLines(); });
 
     // Initial render if enabled
     if (enabled) sync();


### PR DESCRIPTION
## Summary
- Adds a **\"כיוון שיגור\" (Launch Direction)** toggle in the experimental menu that, when enabled, draws dashed prediction lines through active red alert clusters to indicate the likely launch trajectory
- Uses **PCA (principal component analysis)** to fit a line through alert zone polygon vertices, with area-weighted centroid for accuracy
- **Clusters alerts** by Voronoi polygon adjacency (union-find on shared vertices), so multiple simultaneous attacks from different directions each get their own prediction line
- Extends lines asymmetrically toward the estimated source country (Lebanon ~2°, Syria ~5.5°, Iran ~25°, Yemen ~20°, Gaza ~1.5°)
- Draws a **1-sigma uncertainty band** around the line; skips drawing if the cluster is too round (elongation < 2.5) or too small (span < 0.1°)
- **Geodesic arcs** trace the great circle for long-distance lines to account for Earth's curvature
- Clips lines at the Mediterranean coastline
- Gated behind **\`?f-predict\`** feature flag while accuracy is being refined
- Prediction lines update in real-time as alerts change and work with the timeline/history scrubber
- Toggle state persists in \`localStorage\`; script lazy-loads on first enable

Closes #79

## Test plan
- [x] Unit tests: \`fitLine\` (PCA) returns correct center and direction for horizontal, vertical, diagonal, and noisy point sets
- [x] Unit tests: \`clusterByAdjacency\` correctly groups adjacent polygons and separates non-touching ones via union-find
- [x] Unit tests: direction detection for Iran/Yemen/Gaza/Lebanon scenarios
- [x] Unit tests: Mediterranean safety net, northern bias, elongation and span filters
- [ ] Manual: open \`/?f-predict\`, enable \"כיוון שיגור\" in menu under \"אזור ניסיוני\", inject mock alerts and verify lines appear
- [ ] Manual: verify button toggles correctly and state persists across page reload with \`?f-predict\`
- [ ] Manual: verify prediction lines update when scrubbing the timeline