### PR TITLE
Fix history dedup: use < instead of <= to not drop same-second entries

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1826,7 +1826,7 @@ body.idle #right-panel {
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i];
       var alertDate = entry.alertDate || '';
-      if (lastHistoryDate && alertDate <= lastHistoryDate) continue;
+      if (lastHistoryDate && alertDate < lastHistoryDate) continue;
       processHistoryEntry(entry);
       newEntries++;
     }


### PR DESCRIPTION
Fixes #70.

`processHistoryEntries()` used `<=` to skip already-processed entries, which incorrectly dropped any new entry sharing the exact same timestamp as the last processed one. Changed to `<` so boundary entries are re-evaluated. Re-processing of same-timestamp entries on subsequent polls is harmless — `recordHistory()` deduplicates by title within a 1-minute window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed history processing logic that was incorrectly skipping entries with identical timestamps. These entries are now properly processed and counted in the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->