### PR TITLE
Consolidate UI controls into hamburger menu

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -242,6 +242,11 @@ body.has-overlay .leaflet-interactive { pointer-events: none !important; }
   padding: 12px 16px;
   cursor: pointer;
   transition: background 0.15s;
+  width: 100%;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
 }
 @media (hover: hover) {
   .menu-item-row:hover { background: #f5f5f5; }
@@ -570,24 +575,24 @@ body.idle #right-panel {
 </button>
 <div id="menu-panel">
   <div id="menu-gps" class="menu-item">
-    <div class="menu-item-row">
+    <button class="menu-item-row" type="button">
       <span class="menu-item-icon"><span class="blue-dot"></span></span>
       <span class="menu-item-label">הראה אותי</span>
       <span class="menu-check"></span>
-    </div>
+    </button>
   </div>
   <div id="menu-zoom" class="menu-item">
-    <div class="menu-item-row">
+    <button class="menu-item-row" type="button">
       <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L14.5 4.5M12 2L9.5 4.5M12 22L9.5 19.5M12 22L14.5 19.5M2 12L4.5 9.5M2 12L4.5 14.5M22 12L19.5 14.5M22 12L19.5 9.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="3.5" stroke="currentColor" stroke-width="2" fill="transparent"/><path d="M14.5 14.5L17.5 17.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></span>
       <span class="menu-item-label">זום אוטומטי</span>
       <span class="menu-check"></span>
-    </div>
+    </button>
   </div>
   <div id="menu-sound" class="menu-item">
-    <div id="menu-sound-row" class="menu-item-row">
+    <button id="menu-sound-row" class="menu-item-row" type="button">
       <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5L6 9H2v6h4l5 4V5z"/><line x1="23" y1="9" x2="17" y2="15"/><line x1="17" y1="9" x2="23" y2="15"/></svg></span>
       <span class="menu-item-label">מצב שקט</span>
-    </div>
+    </button>
     <div class="menu-sub-panel">
       <p style="margin:0 0 8px; font-weight:bold;">בחר מיקום לקבלת התרעות קוליות:</p>
       <input type="text" id="sound-search" placeholder="חפש יישוב..." dir="rtl"
@@ -599,19 +604,19 @@ body.idle #right-panel {
     </div>
   </div>
   <div id="menu-share" class="menu-item" style="display:none;">
-    <div class="menu-item-row">
+    <button class="menu-item-row" type="button">
       <span class="menu-item-icon">
         <svg id="share-icon-ios" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><polyline points="8 6 12 2 16 6"/><line x1="12" y1="2" x2="12" y2="15"/><path d="M20 14v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-5"/></svg>
         <svg id="share-icon-android" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
       </span>
       <span class="menu-item-label">שתף</span>
-    </div>
+    </button>
   </div>
   <div id="menu-about" class="menu-item">
-    <div class="menu-item-row">
+    <button class="menu-item-row" type="button">
       <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><circle cx="12" cy="8" r="0.5" fill="currentColor"/></svg></span>
       <span class="menu-item-label">אודות</span>
-    </div>
+    </button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Move sound, GPS, auto-zoom, share, and about controls into a single menu button at the top-right corner
- Timeline and ellipse buttons remain in the bottom-right panel
- GPS and auto-zoom use checkbox toggle indicators; sound expands an inline sub-panel for location selection
- Share is shown only on touch devices; about opens the existing modal
- Narrow location popups and shorten early-warning display label to fit better on mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New hamburger menu consolidating controls; timeline and ellipse remain as standalone buttons.
  * Sound moved into an expandable sub-panel inside the menu.

* **UI Changes**
  * Right-panel controls reorganized into the menu; updated menu visuals and checkmark rows.
  * Popup and timeline sizing/spacings reduced for tighter display.

* **Behavior Updates**
  * Menu open state affects overlay handling; Escape/click-outside/popstate close menu.
  * Idle mode no longer hides GPS or sound; share/about actions moved into the menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->