### PR TITLE
Fix GPS locating label reverting prematurely

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -873,7 +873,8 @@ body.idle #right-panel {
           showUserLocation(urlPos);
           return;
         }
-        setTransient('מאתר...');
+        if (transientTimeout) { clearTimeout(transientTimeout); transientTimeout = null; }
+        gpsLabel.textContent = 'מאתר...';
         startWatching();
         localStorage.removeItem('oref-location-hidden');
       }


### PR DESCRIPTION
## Summary
- The "מאתר..." (locating) label used `setTransient()` which has a 3-second timeout, causing it to revert to "הראה אותי" before the GPS position is actually acquired
- Now the label persists until the geolocation callback fires — either success (`setActive`) or error (`setTransient('מיקום לא זמין')`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPS location activation flow to prevent timing conflicts and ensure the locating status indicator displays correctly when users activate device location through the menu. This resolves intermittent issues that occurred when location detection was triggered multiple times in quick succession, providing improved stability and a more reliable location experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->