### PR TITLE
Fix bugs and polish from ellipse feature review

### DIFF
--- a/web/ellipse-mode.js
+++ b/web/ellipse-mode.js
@@ -536,10 +536,10 @@
         }
       }
 
-      for (var ra = 0; ra < ringsA.length; ra++) {
-        for (var rb = 0; rb < ringsB.length; rb++) {
-          var ptsA = ringsA[ra];
-          var ptsB = ringsB[rb];
+      for (ra = 0; ra < ringsA.length; ra++) {
+        for (rb = 0; rb < ringsB.length; rb++) {
+          ptsA = ringsA[ra];
+          ptsB = ringsB[rb];
           for (var a = 0; a < ptsA.length; a++) {
             var a1 = ptsA[a];
             var a2 = ptsA[(a + 1) % ptsA.length];
@@ -732,7 +732,7 @@
     }
 
     function refreshExtendedVisual() {
-      var userPos = getCurrentUserPosition ? getCurrentUserPosition() : null;
+      var userPos = getCurrentUserPosition();
       var shouldDraw = !!(enabled && userPos);
       if (!shouldDraw) {
         clearExtendedVisual();
@@ -860,7 +860,6 @@
 
     document.addEventListener('app:stateChanged', function() {
       controller.sync(false);
-      controller.refreshExtendedVisual();
     });
     document.addEventListener('app:locationChanged', function() {
       controller.refreshExtendedVisual();

--- a/web/index.html
+++ b/web/index.html
@@ -747,6 +747,10 @@ body.idle #right-panel {
     try { localStorage.setItem('oref-ellipse-mode', '3'); } catch (e) {}
     var s = document.createElement('script');
     s.src = '/ellipse-mode.js';
+    s.onerror = function() {
+      window._ellipseLoading = false;
+      try { localStorage.removeItem('oref-ellipse-mode'); } catch (e) {}
+    };
     document.head.appendChild(s);
   });
 
@@ -1127,6 +1131,8 @@ body.idle #right-panel {
     menuBtn.setAttribute('aria-expanded', 'false');
     menuOpen = false;
     closeSoundSubPanel();
+    document.getElementById('ext-section').classList.remove('ext-open');
+    document.getElementById('ext-chevron').style.transform = '';
     clearSearch();
     updateOverlay();
   }


### PR DESCRIPTION
## Summary

- **Bug:** Reset `_ellipseLoading` and clear `localStorage` on script fetch failure — previously the ellipse enable button would be permanently stuck if the network request failed
- **Bug:** Remove duplicate `refreshExtendedVisual()` from `app:stateChanged` handler — `sync()` already calls it internally, causing an extra async round-trip and visual flicker on every state change
- **UX:** Collapse the "לא מומלץ" sub-panel when the menu closes, consistent with how the sound sub-panel is handled
- **Cleanup:** Remove dead `getCurrentUserPosition ? ... : null` guard (always a function); remove duplicate `var` declarations in `polygonsTouch()` second loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for the ellipse feature with automatic cleanup when script loading fails.

* **UI/UX Improvements**
  * Improved menu close behavior to properly reset accordion state for better consistency.

* **Behavioral Changes**
  * Optimized when visual updates occur in the ellipse feature for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->