### PR TITLE
Enable auto-zoom by default for all users

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -993,7 +993,7 @@ body.idle #right-panel {
   initUserLocation();
 
   // --- State ---
-  var autoZoomActive = localStorage.getItem('oref-auto-zoom') === 'true';
+  var autoZoomActive = localStorage.getItem('oref-auto-zoom') !== 'disabled';
   var isZoomingProgrammatically = false;
 
   if (autoZoomActive) {
@@ -1006,7 +1006,7 @@ body.idle #right-panel {
 
   document.getElementById('menu-zoom').querySelector('.menu-item-row').addEventListener('click', function() {
     autoZoomActive = !autoZoomActive;
-    localStorage.setItem('oref-auto-zoom', autoZoomActive);
+    localStorage.setItem('oref-auto-zoom', autoZoomActive ? 'enabled' : 'disabled');
     document.getElementById('menu-zoom').classList.toggle('active', autoZoomActive);
     if (autoZoomActive) {
       showToast('זום אוטומטי מופעל');


### PR DESCRIPTION
## Summary
- Changed auto-zoom default from off to on for all users
- Existing users who had it off (stored `"false"`) will get it turned on as a one-time reset
- Storage values changed from `true`/`false` to `enabled`/`disabled` for clarity
- Only users who explicitly toggle it off after this change will have `"disabled"` stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-zoom feature initialization and persistence logic for more reliable behavior across browser sessions. The feature now initializes consistently and maintains user preference state with better persistence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->