### PR TITLE
Respect auto-zoom setting in history panel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2570,7 +2570,7 @@ body.idle #right-panel {
       time = clampTime(time);
       slider.value = Math.min(sliderFromTime(time), 999);
       enterHistoryMode(time);
-      maybeZoomToEvent();
+      if (autoZoomActive) maybeZoomToEvent();
     }
 
     // --- Slider input ---
@@ -2579,7 +2579,7 @@ body.idle #right-panel {
       var time = clampTime(timeFromSlider(parseInt(slider.value)));
       slider.value = sliderFromTime(time);
       enterHistoryMode(time);
-      maybeZoomToEvent();
+      if (autoZoomActive) maybeZoomToEvent();
     });
 
     // --- Timeline bands (show duration of active alerts) ---
@@ -2810,7 +2810,7 @@ body.idle #right-panel {
         var curIdx = findEventIdx(newTime);
         if (curIdx !== playEventIdx) {
           playEventIdx = curIdx;
-          var bounds = curIdx >= 0 && getActiveEventBounds() ? boundsForEvent(curIdx) : null;
+          var bounds = autoZoomActive && curIdx >= 0 && getActiveEventBounds() ? boundsForEvent(curIdx) : null;
           if (bounds) {
             isZoomingProgrammatically = true;
             isPlaying = false;


### PR DESCRIPTION
## Summary
- Gate history panel zoom (prev/next buttons, slider, play mode) behind the `autoZoomActive` setting
- Previously, disabling auto-zoom only affected live alerts and timeline panel open — history navigation still forced viewport changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved auto-zoom functionality in timeline mode to respect the auto-zoom setting when navigating history and during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->