### PR TITLE
Respect device rotation lock in PWA

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -4,7 +4,7 @@
   "description": "מפת התרעות פיקוד העורף בזמן אמת",
   "start_url": "/",
   "display": "standalone",
-  "orientation": "any",
+  "orientation": "natural",
   "dir": "rtl",
   "lang": "he",
   "theme_color": "#1a1a2e",


### PR DESCRIPTION
## Summary
- Change `manifest.json` orientation from `"any"` to `"natural"` so the PWA respects the device's OS-level auto-rotation lock

Fixes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app orientation configuration to use device natural orientation instead of any orientation, improving display adaptation across different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->