### PR TITLE
Add wake lock to prevent screen from turning off

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3215,9 +3215,18 @@ body.idle #right-panel {
     }
   });
 
+  // --- Wake lock: prevent screen from turning off ---
+  var _wakeLock = null;
+  function _acquireWakeLock() {
+    if (!('wakeLock' in navigator)) return;
+    navigator.wakeLock.request('screen').then(function(wl) { _wakeLock = wl; }).catch(function() {});
+  }
+  _acquireWakeLock();
+
   // --- Mobile resume: reload if data is stale ---
   document.addEventListener('visibilitychange', function() {
     if (document.visibilityState !== 'visible') return;
+    _acquireWakeLock();
     try {
       var lastPoll = Number(sessionStorage.getItem('oref-last-poll')) || 0;
       if (Date.now() - lastPoll < 30000) return;


### PR DESCRIPTION
Uses the [Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) to keep the screen on while the map is open — same behavior as video apps.

- Acquired on page load
- Re-acquired on `visibilitychange` (wake lock is released automatically when the app goes to background)
- No-ops silently on unsupported browsers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screen wake lock functionality to prevent the display from automatically turning off while you're actively using the app. The screen will remain on during your session, and when you return to the app after switching to other activities, it will automatically refresh to ensure you have the latest data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->