### PR TITLE
Add menu toggle to opt out of wake lock

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3224,15 +3224,16 @@ body.idle #right-panel {
 
   // --- Wake lock: prevent screen from turning off ---
   var _wakeLock = null;
-  var _wakeLockEnabled = localStorage.getItem('oref-wake-lock') !== 'disabled';
+  var _wakeLockEnabled = true;
+  try { _wakeLockEnabled = localStorage.getItem('oref-wake-lock') !== 'disabled'; } catch(e) {}
   var _menuWakeLock = document.getElementById('menu-wakelock');
   if (!('wakeLock' in navigator)) {
-    _menuWakeLock.style.display = 'none';
-  } else {
+    if (_menuWakeLock) _menuWakeLock.style.display = 'none';
+  } else if (_menuWakeLock) {
     if (_wakeLockEnabled) _menuWakeLock.classList.add('active');
     _menuWakeLock.querySelector('.menu-item-row').addEventListener('click', function() {
       _wakeLockEnabled = !_wakeLockEnabled;
-      localStorage.setItem('oref-wake-lock', _wakeLockEnabled ? 'enabled' : 'disabled');
+      try { localStorage.setItem('oref-wake-lock', _wakeLockEnabled ? 'enabled' : 'disabled'); } catch(e) {}
       _menuWakeLock.classList.toggle('active', _wakeLockEnabled);
       if (_wakeLockEnabled) {
         _acquireWakeLock();


### PR DESCRIPTION
Adds a \"שמור מסך דלוק\" (Keep screen on) checkbox to the menu, letting users opt out of the wake lock feature.

- Checked by default (opt-out, not opt-in)
- State persisted in `localStorage` under `oref-wake-lock`
- Hidden on browsers that don't support the Wake Lock API
- Toggling off immediately releases the held lock; toggling on re-acquires it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menu toggle to enable/disable keeping the screen awake; the option only appears in browsers that support wake locks.
  * Preference is saved and persists across sessions.

* **Bug Fixes / Behavior**
  * Wake-lock requests now respect the saved preference (only acquired when enabled); visibility-change and initial load checks are gated by this setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->