### PR TITLE
Add analytics endpoint for visitor counts

### DIFF
--- a/functions/api/analytics.js
+++ b/functions/api/analytics.js
@@ -3,14 +3,29 @@ const SITE_TAG = '8ef04aca8dff4804be044bbbd8f2da66';
 export async function onRequestGet({ env }) {
   const { CF_ACCOUNT_TAG, CF_API_TOKEN } = env;
   if (!CF_ACCOUNT_TAG || !CF_API_TOKEN) {
-    return new Response('Missing CF_ACCOUNT_TAG or CF_API_TOKEN', { status: 500 });
+    return new Response(JSON.stringify({ error: 'Analytics is not configured' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': 'https://oref-map.org',
+      },
+    });
   }
 
   let result;
   try {
     result = await fetchVisitorCounts(CF_ACCOUNT_TAG, CF_API_TOKEN);
   } catch (err) {
-    return new Response(err.message, { status: 502, headers: { 'Cache-Control': 'no-store' } });
+    console.error('analytics fetch failed', err);
+    return new Response(JSON.stringify({ error: 'Failed to fetch analytics' }), {
+      status: 502,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': 'https://oref-map.org',
+      },
+    });
   }
 
   return new Response(JSON.stringify(result), {


### PR DESCRIPTION
## Summary

- Adds `GET /api/analytics` Pages Function that queries the Cloudflare Web Analytics GraphQL API
- Returns visitor counts for the last 1 hour and last 24 hours: `{ visitors_1h, visitors_24h }`
- Response includes `Cache-Control: public, max-age=60` for CDN caching via Cache Rule

## Setup required after deploy

1. Set Pages secrets: `CF_ACCOUNT_TAG` and `CF_API_TOKEN` (Account Analytics: Read permission)
2. Create Cache Rule in Cloudflare dashboard:
   - Expression: `http.request.uri.path eq "/api/analytics"`
   - Edge TTL override: 60 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analytics endpoint that returns visitor counts for the past 1 hour and 24 hours.
  * Responses include short-lived public caching to improve performance.
  * Cross-origin access enabled for the site so analytics can be requested from the frontend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->