### PR TITLE
Fix Web Analytics site tag

### DIFF
--- a/functions/api/analytics.js
+++ b/functions/api/analytics.js
@@ -1,4 +1,4 @@
-const SITE_TAG = '8ef04aca8dff4804be044bbbd8f2da66';
+const SITE_TAG = 'ce9e2bf7c82c46b1b66eb9019a526873';
 
 export async function onRequestGet({ env }) {
   const { CF_ACCOUNT_TAG, CF_API_TOKEN } = env;


### PR DESCRIPTION
The site tag provided was incorrect. Discovered the real site tag by querying the RUM API without a filter — `ce9e2bf7c82c46b1b66eb9019a526873` has 149k events vs the previous tag which had none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site configuration for analytics data retrieval from the Cloudflare API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->