### PR TITLE
Hide wake lock menu item on non-mobile devices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -614,8 +614,8 @@ body.idle #right-panel {
   </div>
   <div id="menu-wakelock" class="menu-item">
     <button class="menu-item-row" type="button">
-      <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></span>
-      <span class="menu-item-label">שמור מסך דלוק</span>
+      <span id="menu-wakelock-icon" class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></span>
+      <span class="menu-item-label">מנע כיבוי מסך</span>
       <span class="menu-check"></span>
     </button>
   </div>
@@ -3226,11 +3226,14 @@ body.idle #right-panel {
   var _wakeLockEnabled = true;
   try { _wakeLockEnabled = localStorage.getItem('oref-wake-lock') !== 'disabled'; } catch(e) {}
   var _menuWakeLock = document.getElementById('menu-wakelock');
-  var _isMobileDevice = (navigator.userAgentData ? navigator.userAgentData.mobile : (('ontouchstart' in window) || navigator.maxTouchPoints > 0));
-  if (!_isMobileDevice) _wakeLockEnabled = false;
-  if (!('wakeLock' in navigator) || !_isMobileDevice) {
+  var _isMobileDevice = (navigator.userAgentData ? navigator.userAgentData.mobile : window.matchMedia('(pointer: coarse) and (hover: none)').matches);
+  if (!('wakeLock' in navigator)) {
     if (_menuWakeLock) _menuWakeLock.style.display = 'none';
   } else if (_menuWakeLock) {
+    if (_isMobileDevice) {
+      var _iconEl = document.getElementById('menu-wakelock-icon');
+      if (_iconEl) _iconEl.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2"/><circle cx="12" cy="18" r="1"/></svg>';
+    }
     if (_wakeLockEnabled) _menuWakeLock.classList.add('active');
     _menuWakeLock.querySelector('.menu-item-row').addEventListener('click', function() {
       _wakeLockEnabled = !_wakeLockEnabled;


### PR DESCRIPTION
## Summary
- Hide the "שמור מסך דלוק" (keep screen on) menu item on desktop browsers, where it is not relevant
- Detection uses `navigator.userAgentData.mobile` (Chromium) with a fallback to touch-points check
- Also updates the about modal description text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the About modal to state the site displays "warning zones" in real time (replacing prior wording about "warning alerts").

* **Bug Fixes**
  * The keep-screen-on (wake-lock) option now only appears and can be enabled on supported mobile devices; it is hidden or disabled on non-mobile devices and where the feature is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->