### PR TITLE
Make presence statistics opt-in

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -932,7 +932,7 @@ body.idle #right-panel {
       if (!resp.ok) throw new Error('presence request failed');
       return resp.json();
     }).then(function(data) {
-      if (data && typeof data.count === 'number') {
+      if (presenceEnabled && data && typeof data.count === 'number') {
         renderVisitorCount(data.count);
       }
     }).catch(function(err) {
@@ -1157,7 +1157,7 @@ body.idle #right-panel {
       if (presenceEnabled) {
         showToast('מספר משתמשים מופעל');
         sendPresenceHeartbeat();
-        if (!presenceIntervalId) presenceIntervalId = setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
+        if (!presenceIntervalId && PRESENCE_URL) presenceIntervalId = setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
       } else {
         showToast('מספר משתמשים כובה');
         if (presenceIntervalId) { clearInterval(presenceIntervalId); presenceIntervalId = null; }


### PR DESCRIPTION
## Summary
- Adds a **סטטיסטיקת נוכחות** menu toggle (off by default)
- Heartbeat is only started when the user enables the toggle; disabling it clears the interval and hides the visitor count
- User preference persisted in `localStorage` under `oref-presence` (`'enabled'`/`'disabled'`), consistent with other toggles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menu option to toggle presence (מספר משתמשים) tracking.
  * Preference is saved and restored across visits.
  * Enabling sends an immediate presence update and starts ongoing updates; disabling stops updates and hides the visitor count.
  * Toast notifications confirm when presence tracking is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->