### PR TITLE
Fix presenceIntervalId ReferenceError

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -955,9 +955,9 @@ body.idle #right-panel {
 
   // Periodically reset proxy so client can re-check if direct /api works
   setInterval(resetProxy, 300000); // 5 min
-  if (presenceEnabled && PRESENCE_URL) {
+  if (PRESENCE_URL) {
     sendPresenceHeartbeat();
-    presenceIntervalId = setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
+    setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
   }
   var LIVE_POLL_MS = 1000;
   var HISTORY_POLL_MS = 10000;


### PR DESCRIPTION
## Summary
- Removes undeclared `presenceIntervalId` assignment left by the squash merge of #125
- Heartbeat now starts unconditionally (no `presenceEnabled &&` guard), matching the intended behavior: user is always counted, toggle only controls display