### PR TITLE
Presence: heartbeat always runs, toggle is display-only, default on

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -905,9 +905,8 @@ body.idle #right-panel {
   var visitorCountEl = document.getElementById('visitorCount');
   var presenceSessionId = null;
   var presenceEnabled = (function() {
-    try { return localStorage.getItem('oref-presence') === 'enabled'; } catch(e) { return false; }
+    try { return localStorage.getItem('oref-presence') !== 'disabled'; } catch(e) { return true; }
   })();
-  var presenceIntervalId = null;
 
   function createPresenceSessionId() {
     if (window.crypto && typeof window.crypto.randomUUID === 'function') {
@@ -956,9 +955,9 @@ body.idle #right-panel {
 
   // Periodically reset proxy so client can re-check if direct /api works
   setInterval(resetProxy, 300000); // 5 min
-  if (presenceEnabled && PRESENCE_URL) {
+  if (PRESENCE_URL) {
     sendPresenceHeartbeat();
-    presenceIntervalId = setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
+    setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
   }
   var LIVE_POLL_MS = 1000;
   var HISTORY_POLL_MS = 10000;
@@ -1501,10 +1500,8 @@ body.idle #right-panel {
       if (presenceEnabled) {
         showToast('מספר משתמשים מופעל');
         sendPresenceHeartbeat();
-        if (!presenceIntervalId && PRESENCE_URL) presenceIntervalId = setInterval(sendPresenceHeartbeat, PRESENCE_POLL_MS);
       } else {
         showToast('מספר משתמשים כובה');
-        if (presenceIntervalId) { clearInterval(presenceIntervalId); presenceIntervalId = null; }
         if (visitorCountEl) visitorCountEl.style.display = 'none';
       }
     });


### PR DESCRIPTION
## Summary

- Heartbeat interval starts unconditionally — all users are always counted regardless of their display preference
- The presence toggle now only controls visibility of the visitor count UI element
- Default changed to enabled (opt-out: only disabled if localStorage has `'disabled'`)
- Removed the now-unused `presenceIntervalId` variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced presence detection with improved handling of storage access errors, now defaulting to enabled unless explicitly disabled.
  * Streamlined presence toggle behavior for more consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->