### PR TITLE
Remove trailing slash from sitemap root URL

### DIFF
--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://oref-map.org/</loc>
+    <loc>https://oref-map.org</loc>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Changed `https://oref-map.org/` to `https://oref-map.org` in `web/sitemap.xml` to match the canonical URL as served.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site root URL configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->