### PR TITLE
Enter history mode at current time when opening panel via location click

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3363,9 +3363,9 @@ body.idle #right-panel {
         extendedHistory.sort(function(a, b) { return a.alertDate - b.alertDate; });
         renderTicks();
         if (seekMode === 'none') {
-          slider.value = 999; // stay at current time, don't enter history mode
-          label.textContent = '';
-          document.getElementById('historyTimeLabel').style.display = 'none';
+          var now = clampTime(Date.now());
+          slider.value = sliderFromTime(now);
+          enterHistoryMode(now);
         } else if (eventPeaks.length > 0) {
           if (seekMode === 'first') {
             seekTo(eventPeaks[0]);


### PR DESCRIPTION
## Summary

- Follow-up to #145: `seekMode='none'` was leaving the panel in live mode with `currentViewTime=0`, which broke prev/next event buttons and showed no time label
- Now enters history mode at `Date.now()` so the slider reflects the current position in the day and all timeline controls work immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline now transitions to history mode at the current timestamp when in 'none' seek mode, rather than reverting to a default slider position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->