### PR TITLE
Add calendar date picker to timeline date navigation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -639,7 +639,86 @@ body.f-predict #menu-predict.f-gated { display: block !important; }
   white-space: nowrap;
   color: #78350f;
   padding: 0 2px;
+  cursor: pointer;
+  text-decoration: underline dotted;
 }
+#tl-date-label:hover { color: #451a03; }
+#date-picker-popup {
+  position: absolute;
+  z-index: 9999;
+  background: #fffbeb;
+  border: 1px solid #f59e0b;
+  border-radius: 10px;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.18);
+  padding: 10px;
+  min-width: 220px;
+  direction: ltr;
+  user-select: none;
+  -webkit-user-select: none;
+}
+#date-picker-popup .dp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+#date-picker-popup .dp-month-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: #78350f;
+}
+#date-picker-popup .dp-nav {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  color: #92400e;
+  padding: 2px 7px;
+  border-radius: 999px;
+}
+#date-picker-popup .dp-nav:hover { background: #fde68a; }
+#date-picker-popup .dp-nav:disabled { opacity: 0.3; cursor: default; }
+#date-picker-popup .dp-nav:disabled:hover { background: none; }
+#date-picker-popup .dp-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+#date-picker-popup .dp-dow {
+  font-size: 10px;
+  font-weight: 700;
+  text-align: center;
+  color: #a16207;
+  padding: 2px 0;
+}
+#date-picker-popup .dp-day {
+  font-size: 12px;
+  text-align: center;
+  padding: 4px 2px;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #78350f;
+}
+#date-picker-popup .dp-day:hover { background: #fde68a; }
+#date-picker-popup .dp-day.dp-today { font-weight: 700; }
+#date-picker-popup .dp-day.dp-selected { background: #f59e0b; color: #fff; font-weight: 700; }
+#date-picker-popup .dp-day.dp-selected:hover { background: #d97706; }
+#date-picker-popup .dp-day.dp-disabled { opacity: 0.25; cursor: default; pointer-events: none; }
+#date-picker-popup .dp-day.dp-empty { visibility: hidden; }
+body.dark #date-picker-popup {
+  background: #2d2a1a;
+  border-color: #8a6e0b;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.45);
+}
+body.dark #date-picker-popup .dp-month-label { color: #dda520; }
+body.dark #date-picker-popup .dp-nav { color: #dda520; }
+body.dark #date-picker-popup .dp-nav:hover { background: #4a4525; }
+body.dark #date-picker-popup .dp-dow { color: #b8860b; }
+body.dark #date-picker-popup .dp-day { color: #e5d080; }
+body.dark #date-picker-popup .dp-day:hover { background: #4a4525; }
+body.dark #date-picker-popup .dp-day.dp-selected { background: #b8860b; color: #fff; }
+body.dark #date-picker-popup .dp-day.dp-selected:hover { background: #a07800; }
 
 @media (max-width: 480px) {
   #right-panel {
@@ -3897,6 +3976,120 @@ try {
       if (isViewingToday()) return;
       var cur = timelineDate || todayDateStr();
       switchDate(addDays(cur, 1));
+    });
+
+    // --- Date picker popup ---
+    var datePickerPopup = null;
+    var datePickerMonth = null; // 'YYYY-MM' of the currently displayed month
+
+    function closeDatePicker() {
+      if (datePickerPopup) {
+        datePickerPopup.remove();
+        datePickerPopup = null;
+      }
+    }
+
+    function renderDatePicker() {
+      if (!datePickerPopup) return;
+      var today = todayDateStr();
+      var selDate = timelineDate || today;
+      var ym = datePickerMonth; // 'YYYY-MM'
+      var year = parseInt(ym.slice(0, 4), 10);
+      var month = parseInt(ym.slice(5, 7), 10); // 1-based
+
+      var minDate = DAY_HISTORY_MIN_DATE;
+      var maxDate = today;
+
+      // Month label
+      var monthNames = ['January','February','March','April','May','June',
+                        'July','August','September','October','November','December'];
+      var label = monthNames[month - 1] + ' ' + year;
+
+      // Prev/next month boundaries
+      var prevYm = (month === 1) ? (year - 1) + '-12' : year + '-' + String(month - 1).padStart(2, '0');
+      var nextYm = (month === 12) ? (year + 1) + '-01' : year + '-' + String(month + 1).padStart(2, '0');
+      var prevDisabled = (prevYm + '-28' < minDate); // disable if entire prev month is before minDate
+      var nextDisabled = (nextYm + '-01' > maxDate);
+
+      // Days in month
+      var daysInMonth = new Date(year, month, 0).getDate();
+      // Day-of-week for 1st (0=Sun)
+      var firstDow = new Date(year + '-' + String(month).padStart(2, '0') + '-01T12:00:00').getDay();
+
+      var html = '<div class="dp-header">' +
+        '<button class="dp-nav" id="dp-prev"' + (prevDisabled ? ' disabled' : '') + '>&#9666;</button>' +
+        '<span class="dp-month-label">' + label + '</span>' +
+        '<button class="dp-nav" id="dp-next"' + (nextDisabled ? ' disabled' : '') + '>&#9656;</button>' +
+        '</div><div class="dp-grid">';
+
+      var dows = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+      for (var i = 0; i < 7; i++) html += '<span class="dp-dow">' + dows[i] + '</span>';
+
+      // Empty cells before first day
+      for (var i = 0; i < firstDow; i++) html += '<span class="dp-day dp-empty"></span>';
+
+      for (var d = 1; d <= daysInMonth; d++) {
+        var ds = year + '-' + String(month).padStart(2, '0') + '-' + String(d).padStart(2, '0');
+        var cls = 'dp-day';
+        if (ds === today) cls += ' dp-today';
+        if (ds === selDate) cls += ' dp-selected';
+        if (ds < minDate || ds > maxDate) cls += ' dp-disabled';
+        html += '<span class="' + cls + '" data-date="' + ds + '">' + d + '</span>';
+      }
+
+      html += '</div>';
+      datePickerPopup.innerHTML = html;
+
+      datePickerPopup.querySelector('#dp-prev').addEventListener('click', function(e) {
+        e.stopPropagation();
+        datePickerMonth = prevYm;
+        renderDatePicker();
+      });
+      datePickerPopup.querySelector('#dp-next').addEventListener('click', function(e) {
+        e.stopPropagation();
+        datePickerMonth = nextYm;
+        renderDatePicker();
+      });
+      datePickerPopup.querySelectorAll('.dp-day:not(.dp-disabled):not(.dp-empty)').forEach(function(el) {
+        el.addEventListener('click', function(e) {
+          e.stopPropagation();
+          var picked = el.getAttribute('data-date');
+          closeDatePicker();
+          if (picked !== (timelineDate || todayDateStr())) switchDate(picked);
+        });
+      });
+    }
+
+    function openDatePicker() {
+      if (datePickerPopup) { closeDatePicker(); return; }
+      var cur = timelineDate || todayDateStr();
+      datePickerMonth = cur.slice(0, 7); // 'YYYY-MM'
+
+      datePickerPopup = document.createElement('div');
+      datePickerPopup.id = 'date-picker-popup';
+
+      // Position below the date label
+      var rect = dateLabel.getBoundingClientRect();
+      datePickerPopup.style.top = (rect.bottom + window.scrollY + 6) + 'px';
+      datePickerPopup.style.left = Math.max(4, rect.left + window.scrollX - 80) + 'px';
+
+      document.body.appendChild(datePickerPopup);
+      renderDatePicker();
+    }
+
+    dateLabel.addEventListener('click', function(e) {
+      e.stopPropagation();
+      openDatePicker();
+    });
+
+    document.addEventListener('click', function(e) {
+      if (datePickerPopup && !datePickerPopup.contains(e.target)) {
+        closeDatePicker();
+      }
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && datePickerPopup) closeDatePicker();
     });
 
     btnRow.addEventListener('click', function(e) {

--- a/web/index.html
+++ b/web/index.html
@@ -3842,6 +3842,7 @@ try {
 
     function closeTimeline() {
       if (!isOpen()) return;
+      closeDatePicker();
       closeUnifiedPanel();
       stopPlay();
 
@@ -4100,8 +4101,11 @@ try {
     });
 
     document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape' && datePickerPopup) closeDatePicker();
-    });
+      if (e.key === 'Escape' && datePickerPopup) {
+        closeDatePicker();
+        e.stopImmediatePropagation();
+      }
+    }, true);
 
     btnRow.addEventListener('click', function(e) {
       if (!isOpen()) {

--- a/web/index.html
+++ b/web/index.html
@@ -640,7 +640,6 @@ body.f-predict #menu-predict.f-gated { display: block !important; }
   color: #78350f;
   padding: 0 2px;
   cursor: pointer;
-  text-decoration: underline dotted;
 }
 #tl-date-label:hover { color: #451a03; }
 #date-picker-popup {
@@ -4067,14 +4066,26 @@ try {
 
       datePickerPopup = document.createElement('div');
       datePickerPopup.id = 'date-picker-popup';
-
-      // Position below the date label
-      var rect = dateLabel.getBoundingClientRect();
-      datePickerPopup.style.top = (rect.bottom + window.scrollY + 6) + 'px';
-      datePickerPopup.style.left = Math.max(4, rect.left + window.scrollX - 80) + 'px';
-
+      // Use fixed positioning (viewport-relative) so it floats above the fixed timeline panel.
+      // Render invisible first to measure height, then place above the date label.
+      datePickerPopup.style.position = 'fixed';
+      datePickerPopup.style.visibility = 'hidden';
+      datePickerPopup.style.top = '0';
+      datePickerPopup.style.left = '0';
       document.body.appendChild(datePickerPopup);
       renderDatePicker();
+
+      var rect = dateLabel.getBoundingClientRect();
+      var popH = datePickerPopup.offsetHeight;
+      var popW = datePickerPopup.offsetWidth;
+      var top = rect.top - popH - 6;
+      var left = rect.left + rect.width / 2 - popW / 2;
+      // Keep within viewport
+      if (top < 4) top = rect.bottom + 6;
+      left = Math.min(Math.max(left, 4), window.innerWidth - popW - 4);
+      datePickerPopup.style.top = top + 'px';
+      datePickerPopup.style.left = left + 'px';
+      datePickerPopup.style.visibility = '';
     }
 
     dateLabel.addEventListener('click', function(e) {

--- a/web/index.html
+++ b/web/index.html
@@ -4000,8 +4000,8 @@ try {
       var maxDate = today;
 
       // Month label
-      var monthNames = ['January','February','March','April','May','June',
-                        'July','August','September','October','November','December'];
+      var monthNames = ['ינואר','פברואר','מרץ','אפריל','מאי','יוני',
+                        'יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'];
       var label = monthNames[month - 1] + ' ' + year;
 
       // Prev/next month boundaries
@@ -4021,7 +4021,7 @@ try {
         '<button class="dp-nav" id="dp-next"' + (nextDisabled ? ' disabled' : '') + '>&#9656;</button>' +
         '</div><div class="dp-grid">';
 
-      var dows = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+      var dows = ['א','ב','ג','ד','ה','ו','ש'];
       for (var i = 0; i < 7; i++) html += '<span class="dp-dow">' + dows[i] + '</span>';
 
       // Empty cells before first day


### PR DESCRIPTION
## Summary

- Clicking the date label in the timeline now opens a popup calendar, enabling fast navigation to any historical date without clicking through days one at a time with the arrow buttons
- The popup appears above the date label (using `position: fixed`) so it never hides the timeline or map content
- Dates before the earliest available history (`DAY_HISTORY_MIN_DATE`) and after today are shown greyed out and are not clickable
- The currently viewed date is highlighted; month navigation disables prev/next when out of range
- Supports dark mode; closes on outside click or Escape key

## Test plan

- [ ] Open the timeline and click the date label — calendar popup appears above it
- [ ] Navigate months with ◂/▸ — prev/next disable at history boundary and today
- [ ] Click a past date — timeline switches to that day's history
- [ ] Click the selected date — popup closes, no unnecessary re-fetch
- [ ] Click outside the popup or press Escape — popup closes
- [ ] Verify arrow buttons still work as before
- [ ] Test in dark mode — popup matches the dark theme
- [ ] Test on mobile (≤480px) — popup stays within viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive date-picker popup for the timeline: click the date label to open a calendar, navigate months, and pick a date.
  * Visual states for today, selected, disabled and empty days; hover/cursor affordance on the date label.
  * Popup auto-positions within the viewport, respects minimum/maximum date bounds, and closes on outside click or Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->