### PR TITLE
Ignore 'היכנסו מייד למרחב המוגן' alert to prevent red flash during UAV alarms

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2490,11 +2490,16 @@ try {
       return 'purple';
     }
 
+    // Ignored — "enter shelter immediately" is a secondary alert that often accompanies
+    // UAV alarms, briefly showing as red and confusing users into thinking it's a missile alert.
+    if (title === 'היכנסו מייד למרחב המוגן') {
+      return null;
+    }
+
     // Red — active danger (missiles / non-conventional / terrorists / shelter now)
     if (title === 'ירי רקטות וטילים' ||
         title === 'נשק לא קונבנציונלי' ||
         title === 'חדירת מחבלים' ||
-        title === 'היכנסו מייד למרחב המוגן' ||
         title === 'היכנסו למרחב המוגן') {
       return 'red';
     }
@@ -3030,6 +3035,7 @@ try {
     if (!alert || !alert.data || !alert.title) return;
     var title = (alert.desc || alert.title).replace(/\s+/g, ' ').trim();
     var state = classifyTitle(title);
+    if (state === null) return;
     if (state !== 'green') lastDangerTime = Date.now();
     var locations = alert.data;
     if (!Array.isArray(locations)) return;
@@ -3085,6 +3091,7 @@ try {
     if (!entry || !entry.data || !entry.title) return;
     var title = entry.title.replace(/\s+/g, ' ').trim();
     var state = classifyTitle(title);
+    if (state === null) return;
     // History `data` is a string (single location)
     var location = normalizeGeresh((typeof entry.data === 'string' ? entry.data : String(entry.data)).trim());
     var since = parseAlertDate(entry.alertDate) || Date.now();
@@ -3415,6 +3422,7 @@ try {
         var rid = String(e.rid || '');
         var title = (e.category_desc || '').replace(/\s+/g, ' ').trim();
         var state = classifyTitle(title);
+        if (state === null) continue;
         var location = normalizeGeresh((typeof e.data === 'string' ? e.data : String(e.data)).trim());
         var ts = parseAlertDate(e.alertDate);
         if (!ts) continue;


### PR DESCRIPTION
## Summary

- Fixes maorcc/oref-map#88
- The alert title `היכנסו מייד למרחב המוגן` is a secondary shelter instruction that accompanies UAV alarms. It briefly paints affected areas red, misleading users into thinking a missile/rocket alarm is active when it's actually a drone alarm.
- `classifyTitle()` now returns `null` for this title, and all three call sites (`processLiveAlert`, `processHistoryEntry`, extended history loop) skip entries with a `null` state — so the alert is fully ignored: no map coloring, no timeline entry.

## Test plan

- [ ] Verify normal rocket alarms (`ירי רקטות וטילים`) still show red
- [ ] Verify UAV alarms (`חדירת כלי טיס עוין`) still show purple
- [ ] Verify `היכנסו מייד למרחב המוגן` entries produce no map change (can test via `window.injectAlert`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)