### PR TITLE
Inherit color for generic shelter alerts (#88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,8 @@ Do **not** use `cat`/`category` for classification — the same number is reused
 | `חדירת כלי טיס עוין` | Hostile drone/aircraft | 🟣 Purple |
 | `נשק לא קונבנציונלי` | Non-conventional weapon | 🔴 Red |
 | `חדירת מחבלים` | Terrorist infiltration | 🔴 Red |
-| `היכנסו מייד למרחב המוגן` | Enter shelter immediately | 🔴 Red |
-| `היכנסו למרחב המוגן` | Enter the shelter | 🔴 Red |
+| `היכנסו מייד למרחב המוגן` | Enter shelter immediately | Inherit (red/purple from prior alert; red if none) |
+| `היכנסו למרחב המוגן` | Enter the shelter | Inherit (red/purple from prior alert; red if none) |
 | `בדקות הקרובות צפויות להתקבל התרעות באזורך` | Early warning — Iran launch, sirens expected in ~10 min | 🟡 Yellow |
 | `על תושבי האזורים הבאים לשפר את המיקום למיגון המיטבי בקרבתך...` | Preparedness notice — improve shelter position, enter shelter if alert received | 🟡 Yellow |
 | `יש לשהות בסמיכות למרחב המוגן` | Stay near the shelter | 🟡 Yellow |
@@ -131,6 +131,7 @@ Do **not** use `cat`/`category` for classification — the same number is reused
 - Yellow titles are matched by exact string or substring: `לשפר את המיקום למיגון המיטבי`, `להישאר בקרבתו`.
 - API sometimes uses double spaces in titles — normalize with `.replace(/\s+/g, ' ')` before matching.
 - Unknown titles default to Red and log a console warning.
+- The two `היכנסו ... למרחב המוגן` titles are generic shelter commands and don't specify a threat type. They preserve the location's existing red or purple state; if none, they default to red. These titles never appear in the R2 day-history archive (Oref doesn't push them).
 
 ### Extended History API
 - **URL**: `https://alerts-history.oref.org.il//Shared/Ajax/GetAlarmsHistory.aspx?lang=he&mode=1`

--- a/web/index.html
+++ b/web/index.html
@@ -2525,17 +2525,33 @@ try {
       return 'purple';
     }
 
-    // Red — active danger (missiles / non-conventional / terrorists / shelter now)
+    // Inherit — generic shelter command, preserve existing color (red/purple)
+    if (title === 'היכנסו מייד למרחב המוגן' ||
+        title === 'היכנסו למרחב המוגן') {
+      return 'inherit';
+    }
+
+    // Red — active danger (missiles / non-conventional / terrorists)
     if (title === 'ירי רקטות וטילים' ||
         title === 'נשק לא קונבנציונלי' ||
-        title === 'חדירת מחבלים' ||
-        title === 'היכנסו מייד למרחב המוגן' ||
-        title === 'היכנסו למרחב המוגן') {
+        title === 'חדירת מחבלים') {
       return 'red';
     }
 
     console.warn('Unknown alert title:', title);
     return 'red'; // default to danger for unknown
+  }
+
+  // Resolve 'inherit' state for generic "enter shelter" alerts.
+  // These don't specify a threat type — preserve the location's existing
+  // red/purple state if present, otherwise default to red.
+  function resolveInherit(state, location) {
+    if (state !== 'inherit') return state;
+    var existing = locationStates[location];
+    if (existing && (existing.state === 'red' || existing.state === 'purple')) {
+      return existing.state;
+    }
+    return 'red';
   }
 
   // --- Marker management (feature-state) ---
@@ -3064,8 +3080,8 @@ try {
   function processLiveAlert(alert) {
     if (!alert || !alert.data || !alert.title) return;
     var title = (alert.desc || alert.title).replace(/\s+/g, ' ').trim();
-    var state = classifyTitle(title);
-    if (state !== 'green') lastDangerTime = Date.now();
+    var rawState = classifyTitle(title);
+    if (rawState !== 'green') lastDangerTime = Date.now();
     var locations = alert.data;
     if (!Array.isArray(locations)) return;
     var isNewAlert = alert.id !== lastLiveAlertId;
@@ -3073,6 +3089,7 @@ try {
     var now = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Jerusalem', year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date());
     for (var i = 0; i < locations.length; i++) {
       var loc = normalizeGeresh(locations[i]);
+      var state = resolveInherit(rawState, loc);
       recordHistory(loc, title, now, state);
       if (isLiveMode) {
         setLocationState(loc, state);
@@ -3119,9 +3136,10 @@ try {
   function processHistoryEntry(entry) {
     if (!entry || !entry.data || !entry.title) return;
     var title = entry.title.replace(/\s+/g, ' ').trim();
-    var state = classifyTitle(title);
+    var rawState = classifyTitle(title);
     // History `data` is a string (single location)
     var location = normalizeGeresh((typeof entry.data === 'string' ? entry.data : String(entry.data)).trim());
+    var state = resolveInherit(rawState, location);
     var since = parseAlertDate(entry.alertDate) || Date.now();
     if (state !== 'green' && since > lastDangerTime) lastDangerTime = since;
     recordHistory(location, title, entry.alertDate || '', state);
@@ -3449,8 +3467,9 @@ try {
         if (!e.data || !e.category_desc) continue;
         var rid = String(e.rid || '');
         var title = (e.category_desc || '').replace(/\s+/g, ' ').trim();
-        var state = classifyTitle(title);
+        var rawState = classifyTitle(title);
         var location = normalizeGeresh((typeof e.data === 'string' ? e.data : String(e.data)).trim());
+        var state = resolveInherit(rawState, location);
         var ts = parseAlertDate(e.alertDate);
         if (!ts) continue;
         var compositeKey = location + '|' + (e.alertDate || '').replace('T', ' ');

--- a/web/index.html
+++ b/web/index.html
@@ -2545,9 +2545,13 @@ try {
   // Resolve 'inherit' state for generic "enter shelter" alerts.
   // These don't specify a threat type — preserve the location's existing
   // red/purple state if present, otherwise default to red.
+  // In history/timeline mode, `locationStates` holds the replay snapshot,
+  // so read from `liveLocationStates` (the shadow of real current state)
+  // to mirror where the caller will write via updateShadowState.
   function resolveInherit(state, location) {
     if (state !== 'inherit') return state;
-    var existing = locationStates[location];
+    var source = (!isLiveMode && liveLocationStates) ? liveLocationStates : locationStates;
+    var existing = source[location];
     if (existing && (existing.state === 'red' || existing.state === 'purple')) {
       return existing.state;
     }


### PR DESCRIPTION
Closes #88.

## Summary

The titles `היכנסו מייד למרחב המוגן` and `היכנסו למרחב המוגן` are generic shelter commands and don't specify a threat type. Previously `classifyTitle()` hardcoded them to red, which caused a location currently under a purple drone alert to flip to red when the shelter command arrived (visible for several seconds in the live view before the drone title reasserted itself).

These two titles now return a sentinel `'inherit'` from `classifyTitle()`. A new helper `resolveInherit(state, location)` is called in all three places the live, history, and extended-history entries are processed. It preserves an existing red or purple state on the location and falls back to red only when no prior state exists (green/yellow or unknown).

Note: these two titles never appear in the R2 day-history archive (Oref doesn't push them there), so only live and short-window history paths are affected.

`CLAUDE.md` alert-title table and notes updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shelter-entry alerts now inherit the location’s prior alert color (red or purple), defaulting to red when no prior state exists.
  * Clarified that the two shelter-entry titles are generic (not tied to a specific threat) and are not expected to appear in the R2 day-history archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->