### PR TITLE
Remove redundant array check in polygon loader

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2563,7 +2563,6 @@ try {
     for (var name in data) {
       if (name.charAt(0) === '_') continue; // skip metadata keys (_border, _populations, _copyright, ...)
       var coords = data[name];
-      if (!Array.isArray(coords)) continue;
       var isNested = Array.isArray(coords[0][0]);
       var polygonCoords = isNested ? coords : [coords];
       var feature = {


### PR DESCRIPTION
## Summary
- The `!Array.isArray(coords)` guard in `buildPolygons` previously protected against metadata keys (`_populations`, `_copyright`) that happen to be non-arrays.
- Now that `_`-prefixed keys are skipped explicitly, the guard only masks malformed polygon entries — remove it so bad data fails fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of polygon data processing to ensure malformed coordinate data is now processed rather than skipped, potentially resolving issues with certain polygon rendering or geometry construction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->