### PR TITLE
Hide Ellipse menu behind ?f-ellipse flag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -411,6 +411,7 @@ body.idle #unified-panel.slim { opacity: 0; pointer-events: none; transition: op
 }
 /* Feature-flag-gated elements: hidden by default, shown when flag is active */
 .f-gated { display: none !important; }
+body.f-ellipse #ellipse-stub.f-gated { display: block !important; }
 .menu-item { border-bottom: 1px solid #f0f0f0; }
 .menu-item:last-child { border-bottom: none; }
 .menu-item-row {
@@ -1030,7 +1031,7 @@ try {
           </div>
         </div>
       </div>
-      <div id="ellipse-stub" class="menu-item">
+      <div id="ellipse-stub" class="menu-item f-gated">
         <button class="menu-item-row" type="button" id="ellipse-enable-btn">
           <span class="menu-item-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="12" rx="10" ry="6" transform="rotate(-15 12 12)"/></svg></span>
           <span class="menu-item-label">אליפסה</span>
@@ -1166,6 +1167,7 @@ try {
 
   // Ellipse: auto-load at startup if previously enabled; otherwise lazy-load on first enable
   (function() {
+    if (!FF.ellipse) return;
     var savedMode = 0;
     try { savedMode = Number(localStorage.getItem('oref-ellipse-mode')) || 0; } catch (e) {}
     if (savedMode > 0) {


### PR DESCRIPTION
## Summary
- Ellipse and Projection overlap in purpose and confuse users now that Projection is publicly available.
- Gate the Ellipse menu item with the existing `.f-gated` + `body.f-<name>` pattern, so it only appears when `?f-ellipse` is in the URL.
- Also gate the startup auto-loader behind `FF.ellipse`, so users who previously enabled Ellipse do not have it auto-load without the flag. LocalStorage state is preserved — adding the flag restores their previous state.

## Test plan
- [ ] Visit `/` → Ellipse not visible in the "אזור ניסיוני" submenu.
- [ ] Visit `/?f-ellipse` → Ellipse visible and toggleable.
- [ ] With flag, enable Ellipse, reload with flag → auto-loads.
- [ ] Reload without flag → Ellipse stays dormant; localStorage untouched.
- [ ] Re-add flag → prior state restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved feature flag control for the ellipse menu feature. The feature now properly respects feature flag settings, ensuring it only loads and displays when explicitly enabled. Updated markup and styling to align with the feature flag system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->